### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rojasgabriel/chipmunk-dashboard/security/code-scanning/1](https://github.com/rojasgabriel/chipmunk-dashboard/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top level), so it applies to all jobs unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and for read-only CI tasks (lint/format/test) and does not change intended functionality.

Change region: directly after the `on:` trigger block and before `jobs:`.

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
