### PR TITLE
Bump pygments to >=2.20.0 (CVE-2026-4539)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ dev = [
     "pre-commit>=3.0",
     "pytest>=8.0",
     "pytest-cov>=7.1.0",
+    "pygments>=2.20.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -324,6 +324,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -342,6 +343,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=3.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.13.0" },
@@ -2104,11 +2106,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pins `pygments>=2.20.0` in the `dev` dependency group to resolve Dependabot alert #4
- Fixes CVE-2026-4539: ReDoS via inefficient GUID regex in `AdlLexer` (CVSS 3.3, low severity)
- Pygments is a transitive dev dependency (pulled in by `pytest`, `ipython`, etc.) — no runtime impact

## Test plan

- [ ] CI passes (ruff + pytest)
- [ ] Confirm Dependabot alert #4 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)