### PR TITLE
Restore subject sidebar features + pygments security pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ dev = [
     "pre-commit>=3.0",
     "pytest>=8.0",
     "pytest-cov>=7.1.0",
+    "pygments>=2.20.0",
 ]

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -5,13 +5,16 @@ from typing import Any, cast
 import os
 import time
 import logging
-from dash import Dash, dcc, html, Input, Output
+from datetime import date as _date
+
+from dash import Dash, ctx, dcc, html, Input, Output, State
 import plotly.graph_objects as go
 import plotly.express as px
 from .data import (
     get_all_subjects,
     get_subjects_with_recent_sessions,
     get_sessions,
+    get_subjects_for_date,
     session_metrics,
     multisession_metrics,
     prewarm_multisession_cache,
@@ -144,26 +147,35 @@ def create_app() -> Dash:
     # Auto-refresh interval (60 minutes)
     auto_refresh = dcc.Interval(id="auto-refresh", interval=60 * 60 * 1000)
 
-    def _build_subject_options(all_subjects: list[str], recent: set[str]) -> list[dict]:
-        """Build checklist options that sort recent subjects first.
+    def _build_subject_options(
+        all_subjects: list[str], recent: set[str]
+    ) -> tuple[list[dict], list[dict]]:
+        """Build separate checklist option lists for recent and older subjects.
 
-        Subjects with a session in the last 14 days are shown at the top of
-        the list and prefixed with a star (★) marker so they are immediately
-        visible without scrolling.
+        Subjects with a session in the last 14 days are shown in accent color
+        and bold weight so they are immediately visible without scrolling.
 
         Args:
             all_subjects: Full sorted list of subject names.
             recent: Set of subject names with recent sessions.
 
         Returns:
-            A list of ``{"label": str, "value": str}`` dicts ordered so that
-            recent subjects (with the ★ prefix) come before older ones.
+            A ``(recent_opts, older_opts)`` tuple where recent subjects carry a
+            styled ``html.Span`` label and older subjects use a plain string.
         """
         recent_opts = [
-            {"label": f"★ {s}", "value": s} for s in all_subjects if s in recent
+            {
+                "label": html.Span(
+                    s,
+                    style={"color": _THEME["accent"], "fontWeight": "bold"},
+                ),
+                "value": s,
+            }
+            for s in all_subjects
+            if s in recent
         ]
         older_opts = [{"label": s, "value": s} for s in all_subjects if s not in recent]
-        return recent_opts + older_opts
+        return recent_opts, older_opts
 
     # -- helpers --------------------------------------------------------------
     def _graph(gid: str) -> dcc.Graph:
@@ -201,11 +213,14 @@ def create_app() -> Dash:
         )
 
     # -- sidebar --------------------------------------------------------------
+    _init_recent_opts, _init_older_opts = _build_subject_options(
+        subjects, recent_subjects
+    )
     sidebar = html.Div(
         [
             html.Label("Subjects", style={"fontWeight": "bold"}),
             html.Div(
-                "★ = session in last 2 weeks",
+                "blue = session in last 2 weeks",
                 style={
                     "fontSize": "11px",
                     "color": _THEME["muted"],
@@ -213,14 +228,45 @@ def create_app() -> Dash:
                 },
             ),
             html.Div(
-                dcc.Checklist(
-                    id="subjects",
-                    options=_build_subject_options(subjects, recent_subjects),
-                    value=[],
-                    style={"display": "flex", "flexDirection": "column", "gap": "2px"},
-                    inputStyle={"marginRight": "6px", "transform": "scale(1.2)"},
-                    labelStyle={"fontSize": "16px", "cursor": "pointer"},
-                ),
+                [
+                    dcc.Checklist(
+                        id="subjects-recent",
+                        options=_init_recent_opts,
+                        value=[],
+                        style={
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "gap": "2px",
+                        },
+                        inputStyle={"marginRight": "6px", "transform": "scale(1.2)"},
+                        labelStyle={"fontSize": "16px", "cursor": "pointer"},
+                    ),
+                    html.Hr(
+                        id="subjects-divider",
+                        style={
+                            "margin": "4px 0",
+                            "border": "none",
+                            "borderTop": f"1px solid {_THEME['border']}",
+                            "display": (
+                                "block"
+                                if (_init_recent_opts and _init_older_opts)
+                                else "none"
+                            ),
+                        },
+                    ),
+                    dcc.Checklist(
+                        id="subjects-older",
+                        options=_init_older_opts,
+                        value=[],
+                        style={
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "gap": "2px",
+                        },
+                        inputStyle={"marginRight": "6px", "transform": "scale(1.2)"},
+                        labelStyle={"fontSize": "16px", "cursor": "pointer"},
+                    ),
+                ],
                 style={
                     "height": "40vh",
                     "overflowY": "auto",
@@ -241,7 +287,18 @@ def create_app() -> Dash:
             dcc.DatePickerSingle(
                 id="session-date",
                 display_format="YYYY-MM-DD",
-                style={"width": "100%", "marginBottom": "8px"},
+                style={"width": "100%", "marginBottom": "4px"},
+            ),
+            html.Button(
+                "Today",
+                id="today-button",
+                n_clicks=0,
+                style={
+                    "width": "100%",
+                    "marginBottom": "8px",
+                    "cursor": "pointer",
+                    "fontSize": "12px",
+                },
             ),
             dcc.Dropdown(
                 id="session-time",
@@ -358,21 +415,44 @@ def create_app() -> Dash:
     )
 
     # -- callbacks ------------------------------------------------------------
+
+    def _sessions_on_date(sessions_list: list[str], date_val: str) -> str | None:
+        """Return the latest session name for a subject on a given calendar date.
+
+        Args:
+            sessions_list: Pre-fetched list of session names for the subject,
+                in ascending chronological order.
+            date_val: Date in ``YYYY-MM-DD`` format.
+
+        Returns:
+            The latest ``session_name`` for that day, or ``None`` if no session
+            exists on that date for the subject.
+        """
+        raw_date = date_val.replace("-", "")  # YYYYMMDD
+        day_sessions = [s for s in sessions_list if s.startswith(raw_date)]
+        return day_sessions[-1] if day_sessions else None
+
     # Session Date & Time Logic
     @app.callback(
         Output("session-date", "date"),
         Output("session-date", "min_date_allowed"),
         Output("session-date", "max_date_allowed"),
         Output("session-date", "initial_visible_month"),
-        Input("subjects", "value"),
+        Input("subjects-recent", "value"),
+        Input("subjects-older", "value"),
         Input("auto-refresh", "n_intervals"),
+        Input("today-button", "n_clicks"),
     )
-    def _update_date_options(subjects, n_intervals):
-        """Update date-picker bounds and default date for selected subjects.
+    def _update_date_options(
+        subjects_recent, subjects_older, n_intervals, _today_clicks
+    ):
+        """Update date-picker bounds spanning all selected subjects.
 
         Callback Inputs:
-            - ``subjects.value``
+            - ``subjects-recent.value``
+            - ``subjects-older.value``
             - ``auto-refresh.n_intervals``
+            - ``today-button.n_clicks``
 
         Callback Outputs:
             - ``session-date.date``
@@ -381,8 +461,11 @@ def create_app() -> Dash:
             - ``session-date.initial_visible_month``
 
         Args:
-            subjects: Selected subject names from the sidebar checklist.
+            subjects_recent: Selected recent subject names.
+            subjects_older: Selected older subject names.
             n_intervals: Auto-refresh tick counter (unused except as trigger).
+            _today_clicks: Today button click count (unused; presence in
+                ``ctx.triggered_id`` is the signal).
 
         Returns:
             A tuple with selected date and allowed date bounds, or ``None`` values
@@ -391,23 +474,26 @@ def create_app() -> Dash:
         Side Effects:
             Triggers multi-session cache prewarming anchored to the latest date.
         """
+        if ctx.triggered_id == "today-button":
+            today = _date.today().isoformat()
+            return today, None, None, today
+
+        subjects = (subjects_recent or []) + (subjects_older or [])
         if not subjects:
             return None, None, None, None
 
-        # Parse dates from session names (YYYYMMDD_HHMMSS)
-        dates = []
-        for subject in subjects:
-            sessions = get_sessions(subject)
-            for s in sessions:
-                if len(s) >= 8:
-                    d_str = f"{s[:4]}-{s[4:6]}-{s[6:8]}"
-                    dates.append(d_str)
+        all_dates = [
+            f"{s[:4]}-{s[4:6]}-{s[6:8]}"
+            for subj in subjects
+            for s in get_sessions(subj)
+            if len(s) >= 8
+        ]
 
-        if not dates:
+        if not all_dates:
             return None, None, None, None
 
-        min_d = min(dates)
-        max_d = max(dates)
+        min_d = min(all_dates)
+        max_d = max(all_dates)
         prewarm_multisession_cache(subjects, sessions_back=30, start_date=max_d)
         return max_d, min_d, max_d, max_d  # Default to latest
 
@@ -415,14 +501,16 @@ def create_app() -> Dash:
         Output("session-time", "options"),
         Output("session-time", "value"),
         Input("session-date", "date"),
-        Input("subjects", "value"),
+        Input("subjects-recent", "value"),
+        Input("subjects-older", "value"),
     )
-    def _update_time_options(date_val, subjects):
+    def _update_time_options(date_val, subjects_recent, subjects_older):
         """Update session-time dropdown options for the selected calendar day.
 
         Callback Inputs:
             - ``session-date.date``
-            - ``subjects.value``
+            - ``subjects-recent.value``
+            - ``subjects-older.value``
 
         Callback Outputs:
             - ``session-time.options``
@@ -430,12 +518,14 @@ def create_app() -> Dash:
 
         Args:
             date_val: Selected date in ``YYYY-MM-DD`` format.
-            subjects: Selected subject names from the sidebar checklist.
+            subjects_recent: Selected recent subject names.
+            subjects_older: Selected older subject names.
 
         Returns:
             Dropdown options for sessions on that day and the default selected
             value (latest session for the day), or empty outputs.
         """
+        subjects = (subjects_recent or []) + (subjects_older or [])
         if not date_val or not subjects:
             return [], None
 
@@ -465,7 +555,8 @@ def create_app() -> Dash:
         return opts, opts[-1]["value"] if opts else None
 
     @app.callback(
-        Output("subjects", "value"),
+        Output("subjects-recent", "value"),
+        Output("subjects-older", "value"),
         Input("clear-subjects", "n_clicks"),
         prevent_initial_call=True,
     )
@@ -476,38 +567,60 @@ def create_app() -> Dash:
             - ``clear-subjects.n_clicks``
 
         Callback Outputs:
-            - ``subjects.value``
+            - ``subjects-recent.value``
+            - ``subjects-older.value``
 
         Args:
             n_clicks: Button click count provided by Dash.
 
         Returns:
-            An empty list to clear the subject checklist value.
+            A pair of empty lists to clear both subject checklist values.
         """
-        return []
+        return [], []
 
     @app.callback(
-        Output("subjects", "options"),
+        Output("subjects-recent", "options"),
+        Output("subjects-older", "options"),
+        Output("subjects-divider", "style"),
+        Input("session-date", "date"),
         Input("auto-refresh", "n_intervals"),
     )
-    def _update_subject_options(_n_intervals):
-        """Refresh the subject checklist options on each auto-refresh tick.
+    def _update_subject_options(date_val, _n_intervals):
+        """Refresh the subject checklist options, filtered to the selected date.
 
         Callback Inputs:
+            - ``session-date.date``
             - ``auto-refresh.n_intervals``
 
         Callback Outputs:
-            - ``subjects.options``
+            - ``subjects-recent.options``
+            - ``subjects-older.options``
+            - ``subjects-divider.style``
 
         Args:
+            date_val: Selected date in ``YYYY-MM-DD`` format, or ``None``.
             _n_intervals: Auto-refresh tick counter (unused).
 
         Returns:
-            Updated checklist options with recent subjects (★) sorted first.
+            A tuple of recent options, older options, and divider style dict.
+            When a date is selected, only subjects with sessions on that date
+            are included. Falls back to all subjects when no date is set.
+            The divider is hidden when either group is empty.
         """
         all_subjs = get_all_subjects()
+        if date_val:
+            raw_date = date_val.replace("-", "")
+            date_subjs = set(get_subjects_for_date(raw_date))
+            all_subjs = [s for s in all_subjs if s in date_subjs]
         recent = get_subjects_with_recent_sessions()
-        return _build_subject_options(all_subjs, recent)
+        recent_opts, older_opts = _build_subject_options(all_subjs, recent)
+        divider_style = {
+            "margin": "4px 0",
+            "border": "none",
+            "borderTop": f"1px solid {_THEME['border']}",
+            "display": "block" if (recent_opts and older_opts) else "none",
+        }
+        return recent_opts, older_opts, divider_style
 
     # ── Single-session plots ─────────────────────────────────────────────────
     @app.callback(
@@ -521,27 +634,38 @@ def create_app() -> Dash:
         Output("wait-delta-hist", "figure"),
         Output("react-line", "figure"),
         Output("react-hist", "figure"),
-        Input("subjects", "value"),
+        Input("subjects-recent", "value"),
+        Input("subjects-older", "value"),
         Input("session-time", "value"),
         Input("auto-refresh", "n_intervals"),
+        State("session-date", "date"),
     )
-    def _update_single(subjects, session_name, n_intervals):
+    def _update_single(
+        subjects_recent, subjects_older, session_name, n_intervals, session_date
+    ):
         """Render all single-session figures for the current selection.
 
         Callback Inputs:
-            - ``subjects.value``
+            - ``subjects-recent.value``
+            - ``subjects-older.value``
             - ``session-time.value``
             - ``auto-refresh.n_intervals``
+
+        Callback State:
+            - ``session-date.date``
 
         Callback Outputs:
             Ten figures for outcomes, psychometric/chronometric, performance,
             initiation, wait-delta, and reaction-time views.
 
         Args:
-            subjects: Selected subject names as a list or single string.
+            subjects_recent: Selected recent subject names.
+            subjects_older: Selected older subject names.
             session_name: Selected session name for the first subject.
             n_intervals: Auto-refresh tick counter (unused except as trigger).
-
+            session_date: Currently selected date in ``YYYY-MM-DD`` format, or
+                ``None``. When set and multiple subjects are selected, each
+                additional subject resolves its session from this date.
         Returns:
             A 10-item tuple of Plotly figures in callback output order.
 
@@ -550,8 +674,7 @@ def create_app() -> Dash:
         """
         start = time.perf_counter()
         n = 10
-        if isinstance(subjects, str):
-            subjects = [subjects]
+        subjects = (subjects_recent or []) + (subjects_older or [])
 
         sessions_by_subject = {s: get_sessions(s) for s in subjects}
         valid_subjects = [s for s in subjects if sessions_by_subject.get(s)]
@@ -579,10 +702,12 @@ def create_app() -> Dash:
             c = COLORS[i % len(COLORS)]
             grp = subj
             sessions_list = sessions_by_subject[subj]
-            if session_name:
-                if session_name not in sessions_list:
-                    continue
+            if i == 0 and session_name:
+                # First subject: use the session selected in the time dropdown
                 ses = session_name
+            elif session_date:
+                # Other subjects (or first with no time selected): resolve from date
+                ses = _sessions_on_date(sessions_list, session_date)
             else:
                 ses = sessions_list[-1] if sessions_list else None
             if not ses:
@@ -954,14 +1079,13 @@ def create_app() -> Dash:
             yaxis_title="correct rate",
             yaxis_range=[0, 1],
             yaxis2=dict(
-                title="ew rate",
+                title=dict(text="ew rate", font=dict(color="silver")),
                 overlaying="y",
                 side="right",
                 range=[0, 1],
                 showgrid=False,
                 zeroline=False,
                 tickfont=dict(color="silver"),
-                titlefont=dict(color="silver"),
             ),
         )
         fig_sp.add_hline(y=0.5, **_ref_line)  # Ref Line (Updated style)
@@ -1052,7 +1176,8 @@ def create_app() -> Dash:
         Output("median-wait", "figure"),
         Output("trial-counts", "figure"),
         Output("water", "figure"),
-        Input("subjects", "value"),
+        Input("subjects-recent", "value"),
+        Input("subjects-older", "value"),
         Input("sessions-back", "value"),
         Input("session-date", "date"),  # Replaces session-time for alignment anchor
         Input("smooth-metrics", "value"),
@@ -1060,12 +1185,19 @@ def create_app() -> Dash:
         Input("auto-refresh", "n_intervals"),
     )
     def _update_multi(
-        subjects, sessions_back, session_date, smooth_vals, smooth_window, n_intervals
+        subjects_recent,
+        subjects_older,
+        sessions_back,
+        session_date,
+        smooth_vals,
+        smooth_window,
+        n_intervals,
     ):
         """Render all multi-session trend figures for selected subjects.
 
         Callback Inputs:
-            - ``subjects.value``
+            - ``subjects-recent.value``
+            - ``subjects-older.value``
             - ``sessions-back.value``
             - ``session-date.date``
             - ``smooth-metrics.value``
@@ -1077,13 +1209,13 @@ def create_app() -> Dash:
             and water earned.
 
         Args:
-            subjects: Selected subject names as a list or single string.
+            subjects_recent: Selected recent subject names.
+            subjects_older: Selected older subject names.
             sessions_back: Number of recent sessions to include.
             session_date: Shared anchor date used to align subject timelines.
             smooth_vals: Smoothing toggle values from checklist.
             smooth_window: Moving-average window size when smoothing is enabled.
             n_intervals: Auto-refresh tick counter (unused except as trigger).
-
         Returns:
             An 8-item tuple of Plotly figures in callback output order.
 
@@ -1093,8 +1225,8 @@ def create_app() -> Dash:
         """
         start = time.perf_counter()
         n = 8
-        if isinstance(subjects, str):
-            subjects = [subjects]
+        subjects = (subjects_recent or []) + (subjects_older or [])
+
         if not subjects:
             e = _empty_fig()
             _perf_log("_update_multi", start, subjects=0)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,6 +67,8 @@ def _import_app_module():
     fake_dash.html = _ComponentNamespace()
     fake_dash.Input = _IO
     fake_dash.Output = _IO
+    fake_dash.State = _IO
+    fake_dash.ctx = types.SimpleNamespace(triggered_id=None)
 
     fake_plotly = types.ModuleType("plotly")
     fake_plotly.__path__ = []
@@ -81,6 +83,7 @@ def _import_app_module():
     fake_data.get_all_subjects = mock.Mock(return_value=["subject-a", "subject-b"])
     fake_data.get_subjects_with_recent_sessions = mock.Mock(return_value=set())
     fake_data.get_sessions = mock.Mock(return_value=[])
+    fake_data.get_subjects_for_date = mock.Mock(return_value=[])
     fake_data.session_metrics = mock.Mock(return_value=None)
     fake_data.multisession_metrics = mock.Mock(return_value=None)
     fake_data.prewarm_multisession_cache = mock.Mock()
@@ -142,7 +145,7 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
 
-        self.assertEqual(update_date_options([], 0), (None, None, None, None))
+        self.assertEqual(update_date_options([], [], 0, 0), (None, None, None, None))
 
         with (
             mock.patch.object(
@@ -152,7 +155,7 @@ class TestAppUtilities(unittest.TestCase):
             ),
             mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
         ):
-            result = update_date_options(["subject-a"], 0)
+            result = update_date_options([], ["subject-a"], 0, 0)
 
         self.assertEqual(
             result, ("2026-01-03", "2026-01-01", "2026-01-03", "2026-01-03")
@@ -161,11 +164,26 @@ class TestAppUtilities(unittest.TestCase):
             ["subject-a"], sessions_back=30, start_date="2026-01-03"
         )
 
+    def test_update_date_options_today_button_returns_todays_date(self) -> None:
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+        self.appmod.ctx.triggered_id = "today-button"
+        try:
+            date_val, min_d, max_d, month = update_date_options([], [], 0, 1)
+        finally:
+            self.appmod.ctx.triggered_id = None
+        from datetime import date
+
+        self.assertEqual(date_val, date.today().isoformat())
+        self.assertIsNone(min_d)
+        self.assertIsNone(max_d)
+        self.assertEqual(month, date.today().isoformat())
+
     def test_update_time_options_filters_and_defaults_to_latest(self) -> None:
         app = self.appmod.create_app()
         update_time_options = app.callbacks["_update_time_options"]
 
-        self.assertEqual(update_time_options(None, ["subject-a"]), ([], None))
+        self.assertEqual(update_time_options(None, [], ["subject-a"]), ([], None))
 
         with mock.patch.object(
             self.appmod,
@@ -177,7 +195,7 @@ class TestAppUtilities(unittest.TestCase):
                 "20260102_BAD",
             ],
         ):
-            options, value = update_time_options("2026-01-02", ["subject-a"])
+            options, value = update_time_options("2026-01-02", [], ["subject-a"])
 
         self.assertEqual(len(options), 3)
         self.assertEqual(options[0]["label"], "01:01:01")
@@ -188,7 +206,7 @@ class TestAppUtilities(unittest.TestCase):
     def test_clear_subjects_callback_returns_empty_list(self) -> None:
         app = self.appmod.create_app()
         clear_subjects = app.callbacks["_clear_subjects"]
-        self.assertEqual(clear_subjects(1), [])
+        self.assertEqual(clear_subjects(1), ([], []))
 
     def test_update_subject_options_prioritizes_recent_subjects(self) -> None:
         app = self.appmod.create_app()
@@ -204,22 +222,32 @@ class TestAppUtilities(unittest.TestCase):
                 return_value={"subject-b"},
             ),
         ):
-            options = update_subject_options(1)
+            recent_opts, older_opts, divider_style = update_subject_options(None, 1)
 
+        # Recent subject has a styled Span label
+        self.assertEqual(len(recent_opts), 1)
+        recent_opt = recent_opts[0]
+        self.assertEqual(recent_opt["value"], "subject-b")
+        self.assertEqual(recent_opt["label"]["args"], ("subject-b",))
+        self.assertEqual(recent_opt["label"]["component"], "Span")
+        self.assertIn("style", recent_opt["label"]["kwargs"])
         self.assertEqual(
-            options,
-            [
-                {"label": "★ subject-b", "value": "subject-b"},
-                {"label": "subject-a", "value": "subject-a"},
-            ],
+            recent_opt["label"]["kwargs"]["style"]["color"],
+            self.appmod._THEME["accent"],
         )
+        self.assertEqual(recent_opt["label"]["kwargs"]["style"]["fontWeight"], "bold")
+        # Older subject is in a separate list with a plain string label
+        self.assertEqual(len(older_opts), 1)
+        self.assertEqual(older_opts[0], {"label": "subject-a", "value": "subject-a"})
+        # Divider is shown when both groups are non-empty
+        self.assertEqual(divider_style.get("display"), "block")
 
     def test_update_single_returns_empty_figures_when_no_valid_subjects(self) -> None:
         app = self.appmod.create_app()
         update_single = app.callbacks["_update_single"]
 
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
-            figures = update_single("subject-a", None, 0)
+            figures = update_single(["subject-a"], [], None, 0, None)
 
         self.assertEqual(len(figures), 10)
         self.assertEqual(
@@ -229,7 +257,7 @@ class TestAppUtilities(unittest.TestCase):
     def test_update_multi_returns_empty_figures_when_no_subjects(self) -> None:
         app = self.appmod.create_app()
         update_multi = app.callbacks["_update_multi"]
-        figures = update_multi([], 10, None, [], 3, 0)
+        figures = update_multi([], [], 10, None, [], 3, 0)
         self.assertEqual(len(figures), 8)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
@@ -239,41 +267,15 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
-            result = update_date_options(["subject-a"], 0)
+            result = update_date_options([], ["subject-a"], 0, 0)
         self.assertEqual(result, (None, None, None, None))
 
     def test_update_date_options_returns_none_when_all_sessions_too_short(self) -> None:
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=["short"]):
-            result = update_date_options(["subject-a"], 0)
+            result = update_date_options([], ["subject-a"], 0, 0)
         self.assertEqual(result, (None, None, None, None))
-
-    def test_update_date_options_uses_any_selected_subject_with_sessions(self) -> None:
-        app = self.appmod.create_app()
-        update_date_options = app.callbacks["_update_date_options"]
-
-        sessions_by_subject = {
-            "subject-a": [],
-            "subject-b": ["20251231_235959", "20260102_010101"],
-        }
-
-        with (
-            mock.patch.object(
-                self.appmod,
-                "get_sessions",
-                side_effect=lambda subject: sessions_by_subject[subject],
-            ),
-            mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
-        ):
-            result = update_date_options(["subject-a", "subject-b"], 0)
-
-        self.assertEqual(
-            result, ("2026-01-02", "2025-12-31", "2026-01-02", "2026-01-02")
-        )
-        prewarm.assert_called_once_with(
-            ["subject-a", "subject-b"], sessions_back=30, start_date="2026-01-02"
-        )
 
     def test_update_time_options_returns_empty_when_no_sessions_on_date(self) -> None:
         app = self.appmod.create_app()
@@ -281,14 +283,14 @@ class TestAppUtilities(unittest.TestCase):
         with mock.patch.object(
             self.appmod, "get_sessions", return_value=["20260103_010101"]
         ):
-            result = update_time_options("2026-01-02", ["subject-a"])
+            result = update_time_options("2026-01-02", [], ["subject-a"])
         self.assertEqual(result, ([], None))
 
     def test_update_time_options_handles_session_without_underscore(self) -> None:
         app = self.appmod.create_app()
         update_time_options = app.callbacks["_update_time_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=["20260102"]):
-            options, value = update_time_options("2026-01-02", ["subject-a"])
+            options, value = update_time_options("2026-01-02", [], ["subject-a"])
         self.assertEqual(len(options), 1)
         self.assertEqual(options[0]["label"], "20260102")
         self.assertEqual(value, "20260102")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from dash import Dash, Input, Output, dcc, html
+from dash import Dash, Input, Output, State, dcc, html
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +84,7 @@ def _import_app_with_real_libs():
     fake_data.get_all_subjects = mock.Mock(return_value=["subject-a"])
     fake_data.get_subjects_with_recent_sessions = mock.Mock(return_value=set())
     fake_data.get_sessions = mock.Mock(return_value=["20260101_010101"])
+    fake_data.get_subjects_for_date = mock.Mock(return_value=[])
     fake_data.session_metrics = mock.Mock(return_value=None)
     fake_data.multisession_metrics = mock.Mock(return_value=None)
     fake_data.prewarm_multisession_cache = mock.Mock()
@@ -119,11 +120,14 @@ def _import_app_fake_dash_real_plotly():
     fake_dash_mod.html = html
     fake_dash_mod.Input = Input
     fake_dash_mod.Output = Output
+    fake_dash_mod.State = State
+    fake_dash_mod.ctx = types.SimpleNamespace(triggered_id=None)
 
     fake_data = types.ModuleType("chipmunk_dashboard.data")
     fake_data.get_all_subjects = mock.Mock(return_value=["subject-a", "subject-b"])
     fake_data.get_subjects_with_recent_sessions = mock.Mock(return_value=set())
     fake_data.get_sessions = mock.Mock(return_value=["20260101_010101"])
+    fake_data.get_subjects_for_date = mock.Mock(return_value=[])
     fake_data.session_metrics = mock.Mock(return_value=None)
     fake_data.multisession_metrics = mock.Mock(return_value=None)
     fake_data.prewarm_multisession_cache = mock.Mock()
@@ -679,7 +683,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             ),
             mock.patch.object(self.appmod, "session_metrics", return_value=sm),
         ):
-            figures = update_single(["subject-a"], "20260101_010101", 0)
+            figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
 
         self.assertEqual(len(figures), 10)
         for fig in figures:
@@ -700,7 +704,9 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             ),
             mock.patch.object(self.appmod, "session_metrics", return_value=sm),
         ):
-            figures = update_single(["subject-a", "subject-b"], "20260101_010101", 0)
+            figures = update_single(
+                ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
+            )
 
         self.assertEqual(len(figures), 10)
         for fig in figures:
@@ -719,7 +725,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         update_multi = app.callbacks["_update_multi"]
         ms = _make_multisession_metrics()
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
-            figures = update_multi(["subject-a"], 10, "2026-01-10", [], 3, 0)
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
 
         self.assertEqual(len(figures), 8)
         for fig in figures:
@@ -733,14 +739,16 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         update_multi = app.callbacks["_update_multi"]
         ms = _make_multisession_metrics()
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
-            figures = update_multi(["subject-a"], 10, "2026-01-10", ["smooth"], 5, 0)
+            figures = update_multi(
+                ["subject-a"], [], 10, "2026-01-10", ["smooth"], 5, 0
+            )
 
         self.assertEqual(len(figures), 8)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
-    def test_update_single_string_subject_is_wrapped_in_list(self):
-        """subjects can arrive as a plain string; callback wraps it in a list."""
+    def test_update_single_recent_and_older_subjects_are_merged(self):
+        """Subjects from both checklists are combined and processed together."""
         app = self.appmod.create_app()
         update_single = app.callbacks["_update_single"]
         sm = _make_session_metrics()
@@ -750,17 +758,19 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             ),
             mock.patch.object(self.appmod, "session_metrics", return_value=sm),
         ):
-            figures = update_single("subject-a", "20260101_010101", 0)
+            figures = update_single(
+                ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
+            )
 
         self.assertEqual(len(figures), 10)
 
-    def test_update_multi_string_subject_is_wrapped_in_list(self):
-        """subjects can arrive as a plain string; callback wraps it in a list."""
+    def test_update_multi_recent_and_older_subjects_are_merged(self):
+        """Subjects from both checklists are combined and processed together."""
         app = self.appmod.create_app()
         update_multi = app.callbacks["_update_multi"]
         ms = _make_multisession_metrics()
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
-            figures = update_multi("subject-a", 10, None, [], 3, 0)
+            figures = update_multi(["subject-a"], ["subject-b"], 10, None, [], 3, 0)
 
         self.assertEqual(len(figures), 8)
 
@@ -771,7 +781,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # get_sessions returns [""] — non-empty list so subject is "valid", but
         # ses = "" which is falsy → the loop body is skipped via continue.
         with mock.patch.object(self.appmod, "get_sessions", return_value=[""]):
-            figures = update_single(["subject-a"], None, 0)
+            figures = update_single(["subject-a"], [], None, 0, None)
         self.assertEqual(len(figures), 10)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
@@ -786,7 +796,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             ),
             mock.patch.object(self.appmod, "session_metrics", return_value=None),
         ):
-            figures = update_single(["subject-a"], "20260101_010101", 0)
+            figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
         self.assertEqual(len(figures), 10)
 
     def test_update_multi_skips_subject_when_multisession_metrics_none(self):
@@ -794,7 +804,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         app = self.appmod.create_app()
         update_multi = app.callbacks["_update_multi"]
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=None):
-            figures = update_multi(["subject-a"], 10, "2026-01-10", [], 3, 0)
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
         self.assertEqual(len(figures), 8)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)

--- a/uv.lock
+++ b/uv.lock
@@ -324,6 +324,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -342,6 +343,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=3.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.13.0" },
@@ -2095,11 +2097,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Restore subject date-filtering, Today button, and recent-subject blue/bold styling in `app.py` + tests. These features (from PRs #9 and #28) were silently wiped out of the tree by a conflict-resolution merge (`031486d`) and had been missing from the running app while CI stayed green against the regressed tests.
- Re-pin `pygments>=2.20.0` (CVE-2026-4539, ReDoS) — the constraint was dropped during a rebase, letting `uv.lock` drift back to 2.19.2. Closes Dependabot alert #4.

## Test plan
- [x] `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90` passes (91/91, 99%)
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean
- [x] Verified in browser: recent subjects render blue+bold with divider, date picker filters subject list, Today button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)