### PR TITLE
Wait-floor plot + 4x3 single-session layout + /add-plot skill

### DIFF
--- a/.claude/skills/add-plot/SKILL.md
+++ b/.claude/skills/add-plot/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: add-plot
+description: Add a new Plotly plot to the chipmunk dashboard. Walks the full wiring — optional data-layer extension, layout row, callback Output + return tuple, single/multi-subject adaptive rendering, and test coverage in both test_app.py and test_integration.py — in the correct order. Use when the user asks to add a plot, chart, figure, or visualization to the dashboard.
+---
+
+# Add a plot to the chipmunk dashboard
+
+This skill walks the full wiring for a new Plotly plot. The dashboard has a strict one-way module dependency (`cli.py → app.py → data.py`) and a 90% coverage floor enforced in CI (`--cov-fail-under=90`), so skipping steps fails the build. Follow this checklist in order.
+
+## Step 1 — Gather requirements upfront
+
+Before writing any code, ask the user (batch the questions):
+
+1. **Plot ID and title.** Kebab-case ID (e.g. `water-heatmap`) used as the Dash component id. A human title shown on the figure.
+2. **Section.** Single-session (`_update_single`) or multi-session (`_update_multi`)?
+   - Single-session = metrics from one session, e.g. psychometric curve, per-trial RT, rolling performance within a session.
+   - Multi-session = trends across sessions, e.g. daily water earned, side bias over time.
+3. **Data source.** An existing key returned from `session_metrics` / `multisession_metrics` in `data.py`, OR a new metric that needs computing. If new, is the metric trial-level (extend `session_metrics`) or session-aggregate (extend `multisession_metrics`)?
+4. **Figure type.** `go.Bar`, `go.Scatter`, `go.Box`, `go.Histogram`, `go.Heatmap`, etc.
+5. **Row placement.** Append to an existing `_row(...)` in the target section, or add a new row? If new, where in the section?
+6. **Single-session only:** does the plot need adaptive single- vs. multi-subject rendering? Most existing single-session plots do (vertical bars/histograms for 1 subject; horizontal bars / box plots for many). Check existing plots like `frac-correct`, `p-right`, `rt-hist` for the pattern.
+
+Do not begin writing code until these are answered.
+
+## Step 2 — (Optional) Extend the data layer
+
+Only if the user selected "new metric." Path: `src/chipmunk_dashboard/data.py`.
+
+**Preferred path — extend an existing function.** Compute the new metric inside `session_metrics` (trial-level) or `multisession_metrics` (session-aggregate) and add it as a new key in the dict these functions return. No new top-level query function is needed. Update `tests/test_data.py` with a test that covers the new key — follow the mock pattern used by other tests in the file.
+
+**Only if the query shape is genuinely new:** add a new top-level function. Requirements:
+- Decorate with `@_ttl_lru_cache(maxsize=...)` (see existing decorators in the file for sizing).
+- Read the DB under `with _DB_LOCK:`.
+- Register `<new_func>.cache_clear()` inside `clear_data_cache()` — grep the file for `cache_clear()` to find the block and add it there. Forgetting this leaks stale data across date rollovers.
+- Add a mock-based unit test in `tests/test_data.py`. `test_get_subjects_for_date_filters_at_query` is a recent reference.
+
+Remember: `data.py` is never imported by anything other than `app.py`. Don't leak DB calls into `app.py`.
+
+## Step 3 — Wire the layout
+
+Path: `src/chipmunk_dashboard/app.py`. Grep for `single_section =` and `multi_section =` to find the two sections (line numbers drift — always grep, don't hard-code).
+
+- **Append to an existing row:** add the new plot ID as a string to the `_row(...)` call. Existing rows group related metrics (e.g. psychometric curve + chronometric curve live together).
+- **New row:** create a new `_row("id1", "id2", ...)` call in the list of row arguments for the section's `html.Div(...)`. Rows render left-to-right in a CSS grid of `repeat(N, 1fr)` where N is the number of ids.
+
+## Step 4 — Wire the callback
+
+Same file: `src/chipmunk_dashboard/app.py`. Two big callbacks:
+- `_update_single` — decorated with `@app.callback(...)`, driven by subject + session selection, returns a tuple of 10 figures today.
+- `_update_multi` — driven by subject + sessions-back + smoothing controls, returns a tuple of 8 figures today.
+
+**Both the decorator Output list and the return tuple must change in lockstep.** The Nth `Output(...)` must correspond to the Nth item in the return tuple — they are matched positionally by Dash. Get this wrong and Dash silently puts figures in the wrong components.
+
+### Adding the Output and return position
+
+1. Add `Output("<plot-id>", "figure")` to the decorator in a sensible position (usually adjacent to conceptually related Outputs).
+2. Add the figure variable at the matching position in the return tuple at the end of the callback.
+
+### Building the figure
+
+Inside the callback body:
+- Construct traces using the chosen `go.*` class.
+- Call `_layout(fig, title="…")` to apply shared styling (margins, fonts, hover settings, theme colors). Do **not** set colors/fonts/margins inline — `_layout` and the `_THEME` dict already own that. Inline styling creates inconsistency across plots.
+
+### Adaptive single/multi-subject rendering (single-session plots only)
+
+Most single-session plots render differently depending on subject count:
+- 1 subject: vertical stacked bars, histograms, single-trace scatters.
+- >1 subject: horizontal stacked bars, box plots, faceted or color-grouped scatters.
+
+The branching flag is `multi_col = len(valid_subjects) > 1` (grep `multi_col` in `_update_single` to find usage sites). Follow the pattern: compute both trace shapes and switch inside `if multi_col:` / `else:`. Look at how `frac-correct` (outcome bars) handles this — it's the clearest reference.
+
+If the user said "no adaptive rendering needed," just build a single shape. Note in a code comment that the plot is subject-count-agnostic by design.
+
+## Step 5 — Tests
+
+Both test files must be updated. Coverage below 90% fails CI.
+
+### `tests/test_app.py`
+
+Add a unit test inside `TestAppUtilities` (or a relevant class) that:
+- Calls `create_app()` and looks up the callback via `app.callbacks["_update_single"]` or `["_update_multi"]`.
+- Invokes the callback with mocked `get_sessions` / `session_metrics` / `multisession_metrics` returning shaped data.
+- Asserts the returned figure at the new plot's index has expected properties (trace count, layout title text, axis titles, data length).
+
+Fake-Dash stubs (`_ComponentNamespace`, `_IO`, `_Figure`, `_Dash`) accept any component and trace type, so **no stub updates are needed for a plain plot addition**. Only touch them if the plot introduces a new Dash import (see Gotcha A below).
+
+### `tests/test_integration.py`
+
+Add a test inside `TestCallbacksWithRealPlotly` that:
+- Uses `_make_session_metrics()` / `_make_multisession_metrics()` (grep for these helpers — they build realistic dicts).
+- Calls the real callback and confirms the figure is a `go.Figure` with the expected trace types — this catches plotly library breakage (see the CLAUDE.md note about plotly 6.x `titlefont` removal).
+
+### Gotcha A: new Dash imports
+
+If the plot needs a new import from `dash` (e.g. `State`, `Patch`, `clientside_callback`), update **both**:
+- `_import_app_module` in `tests/test_app.py` — add the attribute to `fake_dash`.
+- `_import_app_fake_dash_real_plotly` in `tests/test_integration.py` — add the attribute to `fake_dash_mod`.
+
+Skipping either causes `AttributeError` at test collection time in a way that's easy to mis-diagnose.
+
+### Gotcha B: tuple/Output ordering drift
+
+After editing, re-count Outputs in the decorator vs. return values in the tuple. They must match exactly. A mismatch silently renders figures in the wrong components.
+
+## Step 6 — Verify
+
+Run, in order:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90
+```
+
+Then — non-negotiable for UI changes — start the app and look at the plot:
+
+```bash
+uv run chipmunk-dashboard run --debug
+```
+
+Select a subject, pick a date. Confirm:
+- The plot renders in the expected row position.
+- It shows sensible data for a real subject.
+- If it has adaptive rendering: select a second subject and confirm the multi-subject shape renders correctly.
+- No layout regressions on other plots (watch for misaligned Outputs/returns).
+
+Tests verify code, not pixels. Skipping browser verification on a UI change is how regressions ship.
+
+## Conventions
+
+- Terse code. No emojis in source or comments.
+- Reference helpers by name, not by line number — line numbers drift.
+- Single-session plots go in `_update_single`; multi-session plots go in `_update_multi`. Do not cross-wire.
+- Every figure goes through `_layout(fig, title=...)`. No inline theming.
+- Match existing naming: kebab-case component ids, snake_case variable names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Four test files, 90 tests, ~98% coverage. No real database required — all `lab
 
 The fake Dash module in `test_app.py` and `_import_app_fake_dash_real_plotly` in `test_integration.py` must expose `Dash`, `dcc`, `html`, `Input`, `Output`, `State`, and `ctx`. When adding new Dash imports to `app.py`, update both fake modules accordingly.
 
-When adding a plot: add a trace in the relevant callback in `app.py`, add the corresponding `Output` to the callback decorator, wire it to the layout, then add coverage in both `test_app.py` and `test_integration.py`.
+When adding a plot, use the `/add-plot` skill (`.claude/skills/add-plot/SKILL.md`) — it walks the full wiring (optional `data.py` extension, layout row, callback `Output` + return-tuple position, single/multi-subject adaptive rendering, and tests in both `test_app.py` and `test_integration.py`).
 
 ## Useful environment variables
 

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -354,8 +354,8 @@ def create_app() -> Dash:
             _row("frac-correct", "p-right", "chrono", "session-perf"),
             # Row 2: Initiation
             _row("init-line", "init-hist"),
-            # Row 3: Wait (Delta)
-            _row("wait-delta-line", "wait-delta-hist"),
+            # Row 3: Wait (Delta + Floor)
+            _row("wait-delta-line", "wait-delta-hist", "wait-floor-line"),
             # Row 4: Reaction
             _row("react-line", "react-hist"),
         ]
@@ -632,6 +632,7 @@ def create_app() -> Dash:
         Output("init-hist", "figure"),
         Output("wait-delta-line", "figure"),
         Output("wait-delta-hist", "figure"),
+        Output("wait-floor-line", "figure"),
         Output("react-line", "figure"),
         Output("react-hist", "figure"),
         Input("subjects-recent", "value"),
@@ -655,8 +656,8 @@ def create_app() -> Dash:
             - ``session-date.date``
 
         Callback Outputs:
-            Ten figures for outcomes, psychometric/chronometric, performance,
-            initiation, wait-delta, and reaction-time views.
+            Eleven figures for outcomes, psychometric/chronometric, performance,
+            initiation, wait-delta, wait-floor, and reaction-time views.
 
         Args:
             subjects_recent: Selected recent subject names.
@@ -667,13 +668,13 @@ def create_app() -> Dash:
                 ``None``. When set and multiple subjects are selected, each
                 additional subject resolves its session from this date.
         Returns:
-            A 10-item tuple of Plotly figures in callback output order.
+            An 11-item tuple of Plotly figures in callback output order.
 
         Side Effects:
             Reads cached session metrics and emits performance logs when enabled.
         """
         start = time.perf_counter()
-        n = 10
+        n = 11
         subjects = (subjects_recent or []) + (subjects_older or [])
 
         sessions_by_subject = {s: get_sessions(s) for s in subjects}
@@ -693,6 +694,7 @@ def create_app() -> Dash:
         fig_pr, fig_ch, fig_sp = go.Figure(), go.Figure(), go.Figure()
         fig_il, fig_ih = go.Figure(), go.Figure()
         fig_wdl, fig_wdh = go.Figure(), go.Figure()
+        fig_wfl = go.Figure()
         fig_rl, fig_rh = go.Figure(), go.Figure()
 
         # Collect outcome totals for multi-subject horizontal bars
@@ -940,6 +942,35 @@ def create_app() -> Dash:
                             line_width=1.5,
                         )
 
+            # --- Row 3 (cont.): Wait Floor ---
+
+            if sm["wait_times"] and sm["wait_trial_nums"]:
+                fig_wfl.add_trace(
+                    go.Scattergl(
+                        x=sm["wait_trial_nums"],
+                        y=sm["wait_times"],
+                        mode="markers",
+                        name=subj,
+                        showlegend=False,
+                        legendgroup=grp,
+                        marker=dict(color=c, size=3, opacity=0.4),
+                        hovertemplate="%{y:.3f}s" + ht_subj,
+                    )
+                )
+                if sm["wait_roll_x"] and sm["wait_roll_y"]:
+                    fig_wfl.add_trace(
+                        go.Scatter(
+                            x=sm["wait_roll_x"],
+                            y=sm["wait_roll_y"],
+                            mode="lines",
+                            name=subj + " roll",
+                            showlegend=False,
+                            legendgroup=grp,
+                            line=dict(color=c, width=2),
+                            hovertemplate="%{y:.3f}s (roll)" + ht_subj,
+                        )
+                    )
+
             # --- Row 4: Reaction Time ---
 
             # Line (RT vs trial)
@@ -1134,6 +1165,12 @@ def create_app() -> Dash:
                 xaxis_title="time (s)",
                 yaxis_title="count",
             )
+        _layout(
+            fig_wfl,
+            title="Wait Floor",
+            xaxis_title="trial number",
+            yaxis_title="time (s)",
+        )
 
         # Row 4
         _layout(
@@ -1162,6 +1199,7 @@ def create_app() -> Dash:
             fig_ih,
             fig_wdl,
             fig_wdh,
+            fig_wfl,
             fig_rl,
             fig_rh,
         )

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -352,12 +352,10 @@ def create_app() -> Dash:
             ),
             # Row 1: Performance / Outcomes
             _row("frac-correct", "p-right", "chrono", "session-perf"),
-            # Row 2: Initiation
-            _row("init-line", "init-hist"),
-            # Row 3: Wait (Delta + Floor)
-            _row("wait-delta-line", "wait-delta-hist", "wait-floor-line"),
-            # Row 4: Reaction
-            _row("react-line", "react-hist"),
+            # Row 2: Timing — per-trial lines (init, wait-delta, wait-floor, react)
+            _row("init-line", "wait-delta-line", "wait-floor-line", "react-line"),
+            # Row 3: Timing — distributions for each column above
+            _row("init-hist", "wait-delta-hist", "wait-floor-hist", "react-hist"),
         ]
     )
 
@@ -633,6 +631,7 @@ def create_app() -> Dash:
         Output("wait-delta-line", "figure"),
         Output("wait-delta-hist", "figure"),
         Output("wait-floor-line", "figure"),
+        Output("wait-floor-hist", "figure"),
         Output("react-line", "figure"),
         Output("react-hist", "figure"),
         Input("subjects-recent", "value"),
@@ -656,7 +655,7 @@ def create_app() -> Dash:
             - ``session-date.date``
 
         Callback Outputs:
-            Eleven figures for outcomes, psychometric/chronometric, performance,
+            Twelve figures for outcomes, psychometric/chronometric, performance,
             initiation, wait-delta, wait-floor, and reaction-time views.
 
         Args:
@@ -668,13 +667,13 @@ def create_app() -> Dash:
                 ``None``. When set and multiple subjects are selected, each
                 additional subject resolves its session from this date.
         Returns:
-            An 11-item tuple of Plotly figures in callback output order.
+            A 12-item tuple of Plotly figures in callback output order.
 
         Side Effects:
             Reads cached session metrics and emits performance logs when enabled.
         """
         start = time.perf_counter()
-        n = 11
+        n = 12
         subjects = (subjects_recent or []) + (subjects_older or [])
 
         sessions_by_subject = {s: get_sessions(s) for s in subjects}
@@ -694,7 +693,7 @@ def create_app() -> Dash:
         fig_pr, fig_ch, fig_sp = go.Figure(), go.Figure(), go.Figure()
         fig_il, fig_ih = go.Figure(), go.Figure()
         fig_wdl, fig_wdh = go.Figure(), go.Figure()
-        fig_wfl = go.Figure()
+        fig_wfl, fig_wfh = go.Figure(), go.Figure()
         fig_rl, fig_rh = go.Figure(), go.Figure()
 
         # Collect outcome totals for multi-subject horizontal bars
@@ -971,6 +970,37 @@ def create_app() -> Dash:
                         )
                     )
 
+                if multi:
+                    fig_wfh.add_trace(
+                        go.Box(
+                            y=sm["wait_times"],
+                            name=subj,
+                            marker_color=c,
+                            legendgroup=grp,
+                            showlegend=False,
+                            boxmean=True,
+                        )
+                    )
+                else:
+                    fig_wfh.add_trace(
+                        go.Histogram(
+                            x=sm["wait_times"],
+                            nbinsx=30,
+                            name=subj,
+                            marker_color=c,
+                            showlegend=False,
+                            opacity=0.8,
+                        )
+                    )
+                    if sm["wait_times"]:
+                        med_val = np.median(sm["wait_times"])
+                        fig_wfh.add_vline(
+                            x=med_val,
+                            line_dash="dash",
+                            line_color="black",
+                            line_width=1.5,
+                        )
+
             # --- Row 4: Reaction Time ---
 
             # Line (RT vs trial)
@@ -1171,6 +1201,15 @@ def create_app() -> Dash:
             xaxis_title="trial number",
             yaxis_title="time (s)",
         )
+        if multi:
+            _layout(fig_wfh, title="Wait Floor Dist.", yaxis_title="time (s)")
+        else:
+            _layout(
+                fig_wfh,
+                title="Wait Floor Dist.",
+                xaxis_title="time (s)",
+                yaxis_title="count",
+            )
 
         # Row 4
         _layout(
@@ -1200,6 +1239,7 @@ def create_app() -> Dash:
             fig_wdl,
             fig_wdh,
             fig_wfl,
+            fig_wfh,
             fig_rl,
             fig_rh,
         )

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -617,6 +617,12 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         wait_delta_x.append(int(np.mean(wait_trial_nums[start : start + win])))
         wait_delta_y.append(float(np.median(wait_delta[start : start + win])))
 
+    # Rolling median of wait actual (20-trial window)
+    wait_roll_x, wait_roll_y = [], []
+    for start in range(0, len(wait_actual) - win + 1, 5):
+        wait_roll_x.append(int(np.mean(wait_trial_nums[start : start + win])))
+        wait_roll_y.append(float(np.median(wait_actual[start : start + win])))
+
     # Rolling EW Rate (20-trial window)
     ew_roll_x, ew_roll_y = [], []
     ew_raw = trials.early_withdrawal.to_numpy()  # 0 or 1
@@ -651,6 +657,8 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         wait_trial_nums=wait_trial_nums.tolist(),
         wait_delta_x=wait_delta_x,
         wait_delta_y=wait_delta_y,
+        wait_roll_x=wait_roll_x,
+        wait_roll_y=wait_roll_y,
         slide_x=slide_x,  # rolling performance x
         slide_y=slide_y,  # rolling performance y
         ew_roll_x=ew_roll_x,  # rolling EW x

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -249,7 +249,7 @@ class TestAppUtilities(unittest.TestCase):
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
             figures = update_single(["subject-a"], [], None, 0, None)
 
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -249,7 +249,7 @@ class TestAppUtilities(unittest.TestCase):
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
             figures = update_single(["subject-a"], [], None, 0, None)
 
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -689,7 +689,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
 
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Single-subject outcome chart: 4 vertical bar traces (one per outcome type)
@@ -699,6 +699,9 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(len(figures[2].data), 1)
         # Wait-floor plot (index 8): raw markers + rolling line = 2 traces
         self.assertEqual(len(figures[8].data), 2)
+        # Wait-floor-hist (index 9): single Histogram trace
+        self.assertEqual(len(figures[9].data), 1)
+        self.assertIsInstance(figures[9].data[0], go.Histogram)
 
     def test_update_single_multi_subject_uses_box_and_horizontal_bars(self):
         app = self.appmod.create_app()
@@ -714,7 +717,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Multi-col outcome chart: 4 horizontal bar traces
@@ -725,8 +728,10 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertIsInstance(figures[5].data[0], go.Box)
         # Wait floor (index 8): raw + rolling traces per subject (2 subjects = 4)
         self.assertEqual(len(figures[8].data), 4)
-        # Reaction time dist uses Box in multi mode
-        self.assertIsInstance(figures[10].data[0], go.Box)
+        # Wait-floor dist (index 9) uses Box in multi mode
+        self.assertIsInstance(figures[9].data[0], go.Box)
+        # Reaction time dist (index 11) uses Box in multi mode
+        self.assertIsInstance(figures[11].data[0], go.Box)
 
     def test_update_multi_with_data_returns_eight_figures(self):
         app = self.appmod.create_app()
@@ -770,7 +775,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
 
     def test_update_multi_recent_and_older_subjects_are_merged(self):
         """Subjects from both checklists are combined and processed together."""
@@ -790,7 +795,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # ses = "" which is falsy → the loop body is skipped via continue.
         with mock.patch.object(self.appmod, "get_sessions", return_value=[""]):
             figures = update_single(["subject-a"], [], None, 0, None)
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
@@ -805,7 +810,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             mock.patch.object(self.appmod, "session_metrics", return_value=None),
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
-        self.assertEqual(len(figures), 11)
+        self.assertEqual(len(figures), 12)
 
     def test_update_multi_skips_subject_when_multisession_metrics_none(self):
         """Line 1128: `if not ms: continue` — multisession_metrics returns None."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -220,6 +220,8 @@ def _make_session_metrics() -> dict:
         wait_trial_nums=trial_nums,
         wait_delta_x=roll_x,
         wait_delta_y=rng.uniform(0.0, 1.0, nroll).tolist(),
+        wait_roll_x=roll_x,
+        wait_roll_y=rng.uniform(0.5, 2.0, nroll).tolist(),
         slide_x=roll_x,
         slide_y=rng.uniform(0.5, 0.9, nroll).tolist(),
         ew_roll_x=roll_x,
@@ -570,6 +572,8 @@ class TestSessionMetricsWithRealLibs(unittest.TestCase):
             "wait_trial_nums",
             "wait_delta_x",
             "wait_delta_y",
+            "wait_roll_x",
+            "wait_roll_y",
             "slide_x",
             "slide_y",
             "ew_roll_x",
@@ -673,7 +677,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.addCleanup(lambda: sys.modules.pop("chipmunk_dashboard.app", None))
         self.appmod = _import_app_fake_dash_real_plotly()
 
-    def test_update_single_single_subject_returns_ten_figures(self):
+    def test_update_single_single_subject_returns_eleven_figures(self):
         app = self.appmod.create_app()
         update_single = app.callbacks["_update_single"]
         sm = _make_session_metrics()
@@ -685,7 +689,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
 
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Single-subject outcome chart: 4 vertical bar traces (one per outcome type)
@@ -693,6 +697,8 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # P(right) and chronometric charts have one trace each
         self.assertEqual(len(figures[1].data), 1)
         self.assertEqual(len(figures[2].data), 1)
+        # Wait-floor plot (index 8): raw markers + rolling line = 2 traces
+        self.assertEqual(len(figures[8].data), 2)
 
     def test_update_single_multi_subject_uses_box_and_horizontal_bars(self):
         app = self.appmod.create_app()
@@ -708,7 +714,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Multi-col outcome chart: 4 horizontal bar traces
@@ -717,8 +723,10 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(figures[0].data[0].orientation, "h")
         # Initiation dist uses Box in multi mode
         self.assertIsInstance(figures[5].data[0], go.Box)
+        # Wait floor (index 8): raw + rolling traces per subject (2 subjects = 4)
+        self.assertEqual(len(figures[8].data), 4)
         # Reaction time dist uses Box in multi mode
-        self.assertIsInstance(figures[9].data[0], go.Box)
+        self.assertIsInstance(figures[10].data[0], go.Box)
 
     def test_update_multi_with_data_returns_eight_figures(self):
         app = self.appmod.create_app()
@@ -762,7 +770,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
 
     def test_update_multi_recent_and_older_subjects_are_merged(self):
         """Subjects from both checklists are combined and processed together."""
@@ -782,7 +790,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # ses = "" which is falsy → the loop body is skipped via continue.
         with mock.patch.object(self.appmod, "get_sessions", return_value=[""]):
             figures = update_single(["subject-a"], [], None, 0, None)
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
@@ -797,7 +805,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             mock.patch.object(self.appmod, "session_metrics", return_value=None),
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
-        self.assertEqual(len(figures), 10)
+        self.assertEqual(len(figures), 11)
 
     def test_update_multi_skips_subject_when_multisession_metrics_none(self):
         """Line 1128: `if not ms: continue` — multisession_metrics returns None."""


### PR DESCRIPTION
## Summary
- **New plot: Wait Floor** — per-trial actual wait time with a rolling median overlay. Surfaces whether animals are clearing progressively longer wait times within a session (Phase 3 training signal).
- **New plot: Wait Floor Distribution** — histogram (single) / box (multi) of actual wait times. One of Lukas's plots from `chipmunk_performance_plots`.
- **Single-session layout reorganized to 4x3 topic-column grid** — each column is one timing topic (initiation, wait delta, wait floor, reaction), line on top, distribution on bottom. Fixes the stretched 2-plot rows on wide monitors and puts wait-time plots adjacent.
- **New `/add-plot` skill** — repo-local Claude Code skill at `.claude/skills/add-plot/SKILL.md` that walks the full wiring for adding a new plot (data-layer extension, layout row, callback Output + return tuple, tests). CLAUDE.md now points to it.

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90` — 91 passed, 99.19% coverage
- [x] Manually verified single-session layout + new plots render for single subject and multi subject in `uv run chipmunk-dashboard run --debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)