### PR TITLE
Refine timing split plots

### DIFF
--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 import os
 import time
 import logging
+import math
 from datetime import date as _date
 
 from dash import Dash, ctx, dcc, html, Input, Output, State
@@ -29,6 +30,7 @@ _AXIS_CLEAN = dict(showgrid=False, zeroline=False, tickfont=dict(color="#56606b"
 _LEGEND: dict[str, Any] = dict(visible=False)
 _PLOT_H = "280px"
 _MAX_W = "560px"  # max width per plot
+_TIMING_Y_CLIP_PCT = 95.0
 _PROFILE_PERF = os.getenv("CHIPMUNK_PROFILE", "0") == "1"
 _LOGGER = logging.getLogger(__name__)
 _THEME = dict(
@@ -100,6 +102,47 @@ def _layout(fig: go.Figure, **kw) -> None:
     # Update defaults with provided kwargs
     config.update(kw)
     fig.update_layout(**config)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Compute a percentile with linear interpolation."""
+    if not values:
+        return float("nan")
+    if len(values) == 1:
+        return float(values[0])
+    p = min(100.0, max(0.0, float(pct)))
+    sorted_vals = sorted(float(v) for v in values)
+    pos = (len(sorted_vals) - 1) * (p / 100.0)
+    lo = int(math.floor(pos))
+    hi = int(math.ceil(pos))
+    if lo == hi:
+        return sorted_vals[lo]
+    frac = pos - lo
+    return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
+
+
+def _robust_y_range(
+    values: list[float],
+    pct: float = _TIMING_Y_CLIP_PCT,
+    lower_bound: float | None = None,
+    min_span: float = 0.05,
+) -> list[float] | None:
+    """Return a median-centered default y-range clipped by percentile radius."""
+    finite = [float(v) for v in values if v is not None and math.isfinite(float(v))]
+    if len(finite) < 2:
+        return None
+    med = _percentile(finite, 50.0)
+    radius = _percentile([abs(v - med) for v in finite], pct)
+    if not math.isfinite(radius) or radius <= 0:
+        radius = min_span
+
+    lo = med - radius
+    hi = med + radius
+    if lower_bound is not None:
+        lo = max(lo, float(lower_bound))
+    if hi <= lo:
+        hi = lo + min_span
+    return [float(lo), float(hi)]
 
 
 def _perf_log(label: str, start_time: float, **fields) -> None:
@@ -352,10 +395,12 @@ def create_app() -> Dash:
             ),
             # Row 1: Performance / Outcomes
             _row("frac-correct", "p-right", "chrono", "session-perf"),
-            # Row 2: Timing — per-trial lines (init, wait-delta, wait-floor, react)
-            _row("init-line", "wait-delta-line", "wait-floor-line", "react-line"),
+            # Row 2: Timing — per-trial lines (init, post-go dwell, wait-floor)
+            _row("init-line", "wait-delta-line", "wait-floor-line"),
             # Row 3: Timing — distributions for each column above
-            _row("init-hist", "wait-delta-hist", "wait-floor-hist", "react-hist"),
+            _row("init-hist", "wait-delta-hist", "wait-floor-hist"),
+            # Row 4: Gap-time + session pacing
+            _row("gap-time", "iti-dist", "trial-count-time"),
         ]
     )
 
@@ -632,8 +677,9 @@ def create_app() -> Dash:
         Output("wait-delta-hist", "figure"),
         Output("wait-floor-line", "figure"),
         Output("wait-floor-hist", "figure"),
-        Output("react-line", "figure"),
-        Output("react-hist", "figure"),
+        Output("gap-time", "figure"),
+        Output("iti-dist", "figure"),
+        Output("trial-count-time", "figure"),
         Input("subjects-recent", "value"),
         Input("subjects-older", "value"),
         Input("session-time", "value"),
@@ -655,8 +701,9 @@ def create_app() -> Dash:
             - ``session-date.date``
 
         Callback Outputs:
-            Twelve figures for outcomes, psychometric/chronometric, performance,
-            initiation, wait-delta, wait-floor, and reaction-time views.
+            Thirteen figures for outcomes, psychometric/chronometric, performance,
+            initiation, post-go center dwell, wait-floor, gap-time, and session
+            pacing views.
 
         Args:
             subjects_recent: Selected recent subject names.
@@ -667,13 +714,13 @@ def create_app() -> Dash:
                 ``None``. When set and multiple subjects are selected, each
                 additional subject resolves its session from this date.
         Returns:
-            A 12-item tuple of Plotly figures in callback output order.
+            A 13-item tuple of Plotly figures in callback output order.
 
         Side Effects:
             Reads cached session metrics and emits performance logs when enabled.
         """
         start = time.perf_counter()
-        n = 12
+        n = 13
         subjects = (subjects_recent or []) + (subjects_older or [])
 
         sessions_by_subject = {s: get_sessions(s) for s in subjects}
@@ -694,7 +741,12 @@ def create_app() -> Dash:
         fig_il, fig_ih = go.Figure(), go.Figure()
         fig_wdl, fig_wdh = go.Figure(), go.Figure()
         fig_wfl, fig_wfh = go.Figure(), go.Figure()
-        fig_rl, fig_rh = go.Figure(), go.Figure()
+        fig_gt = go.Figure()
+        fig_itid = go.Figure()
+        fig_tct = go.Figure()
+        init_y_vals: list[float] = []
+        wait_delta_y_vals: list[float] = []
+        wait_floor_y_vals: list[float] = []
 
         # Collect outcome totals for multi-subject horizontal bars
         multi_outcome_data = []
@@ -843,6 +895,8 @@ def create_app() -> Dash:
                             hovertemplate="%{y:.3f}s (roll)" + ht_subj,
                         )
                     )
+                init_y_vals.extend(sm["init_times"])
+                init_y_vals.extend(sm["init_roll_y"])
 
                 # Hist (Box if multi, Hist if single)
                 if multi:
@@ -877,7 +931,7 @@ def create_app() -> Dash:
                             line_width=1.5,
                         )
 
-            # --- Row 3: Wait Delta ---
+            # --- Row 3: Post-Go Center Dwell ---
 
             if sm["wait_delta_times"]:
                 # Line (Delta vs trial num)
@@ -907,6 +961,8 @@ def create_app() -> Dash:
                             hovertemplate="%{y:.3f}s<extra>rolling</extra>",
                         )
                     )
+                wait_delta_y_vals.extend(sm["wait_delta_times"])
+                wait_delta_y_vals.extend(sm["wait_delta_y"])
 
                 # Hist (Box if multi)
                 if multi:
@@ -969,6 +1025,8 @@ def create_app() -> Dash:
                             hovertemplate="%{y:.3f}s (roll)" + ht_subj,
                         )
                     )
+                wait_floor_y_vals.extend(sm["wait_times"])
+                wait_floor_y_vals.extend(sm["wait_roll_y"])
 
                 if multi:
                     fig_wfh.add_trace(
@@ -1001,67 +1059,136 @@ def create_app() -> Dash:
                             line_width=1.5,
                         )
 
-            # --- Row 4: Reaction Time ---
-
-            # Line (RT vs trial)
-            if sm["rt_trial_nums"]:
-                fig_rl.add_trace(
-                    go.Scattergl(
-                        x=sm["rt_trial_nums"],
-                        y=sm["rt_vals"],
-                        mode="markers",
-                        name=subj,
-                        showlegend=False,
-                        legendgroup=grp,
-                        marker=dict(color=c, size=3, opacity=0.4),
-                        hovertemplate="%{y:.3f}s" + ht_subj,
+            # --- Row 4: Gap Time by Outcome ---
+            gap_correct = sm.get("gap_times_correct", [])
+            gap_incorrect = sm.get("gap_times_incorrect", [])
+            if multi_col:
+                if gap_correct:
+                    fig_gt.add_trace(
+                        go.Violin(
+                            x=[subj] * len(gap_correct),
+                            y=gap_correct,
+                            name="Correct",
+                            legendgroup="gap-correct",
+                            showlegend=i == 0,
+                            line_color="mediumseagreen",
+                            side="negative",
+                            meanline_visible=True,
+                            points=False,
+                            scalegroup=subj,
+                        )
                     )
-                )
-                # Rolling
-                if sm["rt_roll_x"]:
-                    fig_rl.add_trace(
-                        go.Scatter(
-                            x=sm["rt_roll_x"],
-                            y=sm["rt_roll_y"],
-                            mode="lines",
-                            name=subj + " roll",
-                            showlegend=False,
-                            legendgroup=grp,
-                            line=dict(color=c, width=2),
-                            hovertemplate="%{y:.3f}s (roll)" + ht_subj,
+                if gap_incorrect:
+                    fig_gt.add_trace(
+                        go.Violin(
+                            x=[subj] * len(gap_incorrect),
+                            y=gap_incorrect,
+                            name="Incorrect",
+                            legendgroup="gap-incorrect",
+                            showlegend=i == 0,
+                            line_color="tomato",
+                            side="positive",
+                            meanline_visible=True,
+                            points=False,
+                            scalegroup=subj,
+                        )
+                    )
+            else:
+                if gap_correct:
+                    fig_gt.add_trace(
+                        go.Violin(
+                            x=["Correct"] * len(gap_correct),
+                            y=gap_correct,
+                            name="Correct",
+                            legendgroup="gap-correct",
+                            showlegend=True,
+                            line_color="mediumseagreen",
+                            meanline_visible=True,
+                            points=False,
+                        )
+                    )
+                if gap_incorrect:
+                    fig_gt.add_trace(
+                        go.Violin(
+                            x=["Incorrect"] * len(gap_incorrect),
+                            y=gap_incorrect,
+                            name="Incorrect",
+                            legendgroup="gap-incorrect",
+                            showlegend=True,
+                            line_color="tomato",
+                            meanline_visible=True,
+                            points=False,
                         )
                     )
 
-            # Histogram / Box
-            if multi:
-                fig_rh.add_trace(
-                    go.Box(
-                        y=sm["rts"],
-                        name=subj,
-                        marker_color=c,
-                        legendgroup=grp,
-                        showlegend=False,
-                        boxmean=True,
+            iti_vals = sm.get("iti_times", [])
+            if iti_vals:
+                if multi_col:
+                    fig_itid.add_trace(
+                        go.Box(
+                            y=iti_vals,
+                            name=subj,
+                            marker_color=c,
+                            legendgroup=grp,
+                            showlegend=False,
+                            boxmean=True,
+                        )
                     )
-                )
-            else:
-                fig_rh.add_trace(
-                    go.Histogram(
-                        x=sm["rts"],
-                        nbinsx=30,
-                        name=subj,
-                        marker_color=c,
-                        legendgroup=grp,
-                        showlegend=False,
-                        opacity=0.8,
+                else:
+                    fig_itid.add_trace(
+                        go.Histogram(
+                            x=iti_vals,
+                            nbinsx=30,
+                            name=subj,
+                            marker_color=c,
+                            showlegend=False,
+                            opacity=0.8,
+                        )
                     )
-                )
-                # Add Median Line
-                if sm["rts"]:
-                    med_val = np.median(sm["rts"])
-                    fig_rh.add_vline(
-                        x=med_val, line_dash="dash", line_color="black", line_width=1.5
+                    med_val = np.median(iti_vals)
+                    fig_itid.add_vline(
+                        x=med_val,
+                        line_dash="dash",
+                        line_color="black",
+                        line_width=1.5,
                     )
+
+            trial_count_x = sm.get("trial_count_x", [])
+            trial_count_y = sm.get("trial_count_y", [])
+            if trial_count_x and trial_count_y:
+                if multi_col:
+                    fig_tct.add_trace(
+                        go.Scatter(
+                            x=trial_count_x,
+                            y=trial_count_y,
+                            mode="lines+markers",
+                            name=subj,
+                            showlegend=True,
+                            legendgroup=grp,
+                            marker=dict(color=c, size=6),
+                            line=dict(color=c, width=2),
+                            hovertemplate="%{y:.0f}<extra>" + subj + "</extra>",
+                        )
+                    )
+                else:
+                    fig_tct.add_trace(
+                        go.Bar(
+                            x=trial_count_x,
+                            y=trial_count_y,
+                            name=subj,
+                            marker_color=c,
+                            showlegend=False,
+                            hovertemplate="%{y:.0f}<extra></extra>",
+                        )
+                    )
+
+        init_y_range = _robust_y_range(
+            init_y_vals, pct=_TIMING_Y_CLIP_PCT, lower_bound=0
+        )
+        wait_delta_y_range = _robust_y_range(wait_delta_y_vals, pct=_TIMING_Y_CLIP_PCT)
+        wait_floor_y_range = _robust_y_range(
+            wait_floor_y_vals, pct=_TIMING_Y_CLIP_PCT, lower_bound=0
+        )
 
         # --- Layouts ---
 
@@ -1152,21 +1279,12 @@ def create_app() -> Dash:
         fig_sp.add_hline(y=0.5, **_ref_line)  # Ref Line (Updated style)
 
         # Row 2
-
-        # Auto-scale Initiation Y-axis based on 98th percentiles (REVERTED LOGIC)
-        # Recalculate basic 98th percentile logic here if we want *some* filtering,
-        # otherwise, just leave it mostly open but maybe max(10s) floor?
-        # User asked for "normal box plots", "showing outlier points".
-        # If we show outliers, Plotly will scale to them.
-        # But if outliers are HUGE (200s), the box is tiny.
-        # User said "let's back to... showing outlier points".
-        # So we remove manual scaling logic that hides them.
-
         _layout(
             fig_il,
             title="Initiation Times",
             xaxis_title="trial number",
             yaxis_title="time (s)",
+            yaxis_range=init_y_range,
         )
 
         if multi:
@@ -1182,16 +1300,17 @@ def create_app() -> Dash:
         # Row 3
         _layout(
             fig_wdl,
-            title="Wait Delta (Actual - Min)",
+            title="Post-Go Center Dwell",
             xaxis_title="trial number",
             yaxis_title="time (s)",
+            yaxis_range=wait_delta_y_range,
         )
         if multi:
-            _layout(fig_wdh, title="Wait Delta Dist.", yaxis_title="time (s)")
+            _layout(fig_wdh, title="Post-Go Center Dwell Dist.", yaxis_title="time (s)")
         else:
             _layout(
                 fig_wdh,
-                title="Wait Delta Dist.",
+                title="Post-Go Center Dwell Dist.",
                 xaxis_title="time (s)",
                 yaxis_title="count",
             )
@@ -1200,6 +1319,7 @@ def create_app() -> Dash:
             title="Wait Floor",
             xaxis_title="trial number",
             yaxis_title="time (s)",
+            yaxis_range=wait_floor_y_range,
         )
         if multi:
             _layout(fig_wfh, title="Wait Floor Dist.", yaxis_title="time (s)")
@@ -1213,20 +1333,26 @@ def create_app() -> Dash:
 
         # Row 4
         _layout(
-            fig_rl,
-            title="Response Times",
-            xaxis_title="trial number",
+            fig_gt,
+            title="Gap time by outcome",
+            xaxis_title="subject" if multi_col else "outcome",
             yaxis_title="time (s)",
         )
-        if multi:
-            _layout(fig_rh, title="Response Time Dist.", yaxis_title="time (s)")
+        if multi_col:
+            _layout(fig_itid, title="ITIs", yaxis_title="time (s)")
         else:
             _layout(
-                fig_rh,
-                title="Response Time Dist.",
+                fig_itid,
+                title="ITIs",
                 xaxis_title="time (s)",
                 yaxis_title="count",
             )
+        _layout(
+            fig_tct,
+            title="Trial Counts",
+            xaxis_title="minutes from first trial",
+            yaxis_title="count",
+        )
 
         _perf_log("_update_single", start, subjects=len(valid_subjects), multi=multi)
         return (
@@ -1240,8 +1366,9 @@ def create_app() -> Dash:
             fig_wdh,
             fig_wfl,
             fig_wfh,
-            fig_rl,
-            fig_rh,
+            fig_gt,
+            fig_itid,
+            fig_tct,
         )
 
     # ── Multi-session plots ──────────────────────────────────────────────────

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -747,6 +747,21 @@ def create_app() -> Dash:
         init_y_vals: list[float] = []
         wait_delta_y_vals: list[float] = []
         wait_floor_y_vals: list[float] = []
+        wdl_combined_idx: list[int] = []
+        wdl_split_idx: list[int] = []
+        wdh_combined_idx: list[int] = []
+        wdh_split_idx: list[int] = []
+        wfl_combined_idx: list[int] = []
+        wfl_split_idx: list[int] = []
+        wfh_combined_idx: list[int] = []
+        wfh_split_idx: list[int] = []
+        itid_combined_idx: list[int] = []
+        itid_split_idx: list[int] = []
+        wdl_trace_count = 0
+        wdh_trace_count = 0
+        wfl_trace_count = 0
+        wfh_trace_count = 0
+        itid_trace_count = 0
         rt_combined_idx: list[int] = []
         rt_split_idx: list[int] = []
         rt_trace_count = 0
@@ -948,8 +963,11 @@ def create_app() -> Dash:
                         legendgroup=grp,
                         marker=dict(color=c, size=3, opacity=0.4),
                         hovertemplate="%{y:.3f}s<extra>raw</extra>",
+                        visible=True,
                     )
                 )
+                wdl_combined_idx.append(wdl_trace_count)
+                wdl_trace_count += 1
                 # Rolling median line - ensure rolling data exists
                 if sm["wait_delta_x"] and sm["wait_delta_y"]:
                     fig_wdl.add_trace(
@@ -962,10 +980,83 @@ def create_app() -> Dash:
                             legendgroup=grp,
                             line=dict(color=c, width=2),
                             hovertemplate="%{y:.3f}s<extra>rolling</extra>",
+                            visible=True,
                         )
                     )
+                    wdl_combined_idx.append(wdl_trace_count)
+                    wdl_trace_count += 1
+                left_delta_times = sm.get("wait_delta_left_times", [])
+                right_delta_times = sm.get("wait_delta_right_times", [])
+                if left_delta_times and sm.get("wait_trial_nums_left", []):
+                    fig_wdl.add_trace(
+                        go.Scattergl(
+                            x=sm["wait_trial_nums_left"],
+                            y=left_delta_times,
+                            mode="markers",
+                            name="Left",
+                            showlegend=i == 0,
+                            legendgroup="choice-left",
+                            marker=dict(color="royalblue", size=3, opacity=0.4),
+                            hovertemplate="%{y:.3f}s<extra>left</extra>",
+                            visible=False,
+                        )
+                    )
+                    wdl_split_idx.append(wdl_trace_count)
+                    wdl_trace_count += 1
+                if sm.get("wait_delta_left_x", []) and sm.get("wait_delta_left_y", []):
+                    fig_wdl.add_trace(
+                        go.Scatter(
+                            x=sm["wait_delta_left_x"],
+                            y=sm["wait_delta_left_y"],
+                            mode="lines",
+                            name="Left roll",
+                            showlegend=i == 0,
+                            legendgroup="choice-left",
+                            line=dict(color="royalblue", width=2),
+                            hovertemplate="%{y:.3f}s<extra>left rolling</extra>",
+                            visible=False,
+                        )
+                    )
+                    wdl_split_idx.append(wdl_trace_count)
+                    wdl_trace_count += 1
+                if right_delta_times and sm.get("wait_trial_nums_right", []):
+                    fig_wdl.add_trace(
+                        go.Scattergl(
+                            x=sm["wait_trial_nums_right"],
+                            y=right_delta_times,
+                            mode="markers",
+                            name="Right",
+                            showlegend=i == 0,
+                            legendgroup="choice-right",
+                            marker=dict(color="darkorange", size=3, opacity=0.4),
+                            hovertemplate="%{y:.3f}s<extra>right</extra>",
+                            visible=False,
+                        )
+                    )
+                    wdl_split_idx.append(wdl_trace_count)
+                    wdl_trace_count += 1
+                if sm.get("wait_delta_right_x", []) and sm.get(
+                    "wait_delta_right_y", []
+                ):
+                    fig_wdl.add_trace(
+                        go.Scatter(
+                            x=sm["wait_delta_right_x"],
+                            y=sm["wait_delta_right_y"],
+                            mode="lines",
+                            name="Right roll",
+                            showlegend=i == 0,
+                            legendgroup="choice-right",
+                            line=dict(color="darkorange", width=2),
+                            hovertemplate="%{y:.3f}s<extra>right rolling</extra>",
+                            visible=False,
+                        )
+                    )
+                    wdl_split_idx.append(wdl_trace_count)
+                    wdl_trace_count += 1
                 wait_delta_y_vals.extend(sm["wait_delta_times"])
                 wait_delta_y_vals.extend(sm["wait_delta_y"])
+                wait_delta_y_vals.extend(sm.get("wait_delta_left_y", []))
+                wait_delta_y_vals.extend(sm.get("wait_delta_right_y", []))
 
                 # Hist (Box if multi)
                 if multi:
@@ -977,8 +1068,43 @@ def create_app() -> Dash:
                             legendgroup=grp,
                             showlegend=False,
                             boxmean=True,
+                            visible=True,
                         )
                     )
+                    wdh_combined_idx.append(wdh_trace_count)
+                    wdh_trace_count += 1
+                    if left_delta_times:
+                        fig_wdh.add_trace(
+                            go.Box(
+                                x=[subj] * len(left_delta_times),
+                                y=left_delta_times,
+                                name="Left",
+                                marker_color="royalblue",
+                                legendgroup="choice-left",
+                                showlegend=i == 0,
+                                boxmean=True,
+                                offsetgroup="left",
+                                visible=False,
+                            )
+                        )
+                        wdh_split_idx.append(wdh_trace_count)
+                        wdh_trace_count += 1
+                    if right_delta_times:
+                        fig_wdh.add_trace(
+                            go.Box(
+                                x=[subj] * len(right_delta_times),
+                                y=right_delta_times,
+                                name="Right",
+                                marker_color="darkorange",
+                                legendgroup="choice-right",
+                                showlegend=i == 0,
+                                boxmean=True,
+                                offsetgroup="right",
+                                visible=False,
+                            )
+                        )
+                        wdh_split_idx.append(wdh_trace_count)
+                        wdh_trace_count += 1
                 else:
                     fig_wdh.add_trace(
                         go.Histogram(
@@ -988,8 +1114,39 @@ def create_app() -> Dash:
                             marker_color=c,
                             showlegend=False,
                             opacity=0.8,
+                            visible=True,
                         )
                     )
+                    wdh_combined_idx.append(wdh_trace_count)
+                    wdh_trace_count += 1
+                    if left_delta_times:
+                        fig_wdh.add_trace(
+                            go.Histogram(
+                                x=left_delta_times,
+                                nbinsx=30,
+                                name="Left",
+                                marker_color="royalblue",
+                                showlegend=True,
+                                opacity=0.65,
+                                visible=False,
+                            )
+                        )
+                        wdh_split_idx.append(wdh_trace_count)
+                        wdh_trace_count += 1
+                    if right_delta_times:
+                        fig_wdh.add_trace(
+                            go.Histogram(
+                                x=right_delta_times,
+                                nbinsx=30,
+                                name="Right",
+                                marker_color="darkorange",
+                                showlegend=True,
+                                opacity=0.65,
+                                visible=False,
+                            )
+                        )
+                        wdh_split_idx.append(wdh_trace_count)
+                        wdh_trace_count += 1
                     # Add Median Line
                     if sm["wait_delta_times"]:
                         med_val = np.median(sm["wait_delta_times"])
@@ -1013,8 +1170,11 @@ def create_app() -> Dash:
                         legendgroup=grp,
                         marker=dict(color=c, size=3, opacity=0.4),
                         hovertemplate="%{y:.3f}s" + ht_subj,
+                        visible=True,
                     )
                 )
+                wfl_combined_idx.append(wfl_trace_count)
+                wfl_trace_count += 1
                 if sm["wait_roll_x"] and sm["wait_roll_y"]:
                     fig_wfl.add_trace(
                         go.Scatter(
@@ -1026,10 +1186,81 @@ def create_app() -> Dash:
                             legendgroup=grp,
                             line=dict(color=c, width=2),
                             hovertemplate="%{y:.3f}s (roll)" + ht_subj,
+                            visible=True,
                         )
                     )
+                    wfl_combined_idx.append(wfl_trace_count)
+                    wfl_trace_count += 1
+                wait_left_times = sm.get("wait_times_left", [])
+                wait_right_times = sm.get("wait_times_right", [])
+                if wait_left_times and sm.get("wait_trial_nums_left", []):
+                    fig_wfl.add_trace(
+                        go.Scattergl(
+                            x=sm["wait_trial_nums_left"],
+                            y=wait_left_times,
+                            mode="markers",
+                            name="Left",
+                            showlegend=i == 0,
+                            legendgroup="choice-left",
+                            marker=dict(color="royalblue", size=3, opacity=0.4),
+                            hovertemplate="%{y:.3f}s<extra>left</extra>",
+                            visible=False,
+                        )
+                    )
+                    wfl_split_idx.append(wfl_trace_count)
+                    wfl_trace_count += 1
+                if sm.get("wait_left_x", []) and sm.get("wait_left_y", []):
+                    fig_wfl.add_trace(
+                        go.Scatter(
+                            x=sm["wait_left_x"],
+                            y=sm["wait_left_y"],
+                            mode="lines",
+                            name="Left roll",
+                            showlegend=i == 0,
+                            legendgroup="choice-left",
+                            line=dict(color="royalblue", width=2),
+                            hovertemplate="%{y:.3f}s<extra>left rolling</extra>",
+                            visible=False,
+                        )
+                    )
+                    wfl_split_idx.append(wfl_trace_count)
+                    wfl_trace_count += 1
+                if wait_right_times and sm.get("wait_trial_nums_right", []):
+                    fig_wfl.add_trace(
+                        go.Scattergl(
+                            x=sm["wait_trial_nums_right"],
+                            y=wait_right_times,
+                            mode="markers",
+                            name="Right",
+                            showlegend=i == 0,
+                            legendgroup="choice-right",
+                            marker=dict(color="darkorange", size=3, opacity=0.4),
+                            hovertemplate="%{y:.3f}s<extra>right</extra>",
+                            visible=False,
+                        )
+                    )
+                    wfl_split_idx.append(wfl_trace_count)
+                    wfl_trace_count += 1
+                if sm.get("wait_right_x", []) and sm.get("wait_right_y", []):
+                    fig_wfl.add_trace(
+                        go.Scatter(
+                            x=sm["wait_right_x"],
+                            y=sm["wait_right_y"],
+                            mode="lines",
+                            name="Right roll",
+                            showlegend=i == 0,
+                            legendgroup="choice-right",
+                            line=dict(color="darkorange", width=2),
+                            hovertemplate="%{y:.3f}s<extra>right rolling</extra>",
+                            visible=False,
+                        )
+                    )
+                    wfl_split_idx.append(wfl_trace_count)
+                    wfl_trace_count += 1
                 wait_floor_y_vals.extend(sm["wait_times"])
                 wait_floor_y_vals.extend(sm["wait_roll_y"])
+                wait_floor_y_vals.extend(sm.get("wait_left_y", []))
+                wait_floor_y_vals.extend(sm.get("wait_right_y", []))
 
                 if multi:
                     fig_wfh.add_trace(
@@ -1040,8 +1271,43 @@ def create_app() -> Dash:
                             legendgroup=grp,
                             showlegend=False,
                             boxmean=True,
+                            visible=True,
                         )
                     )
+                    wfh_combined_idx.append(wfh_trace_count)
+                    wfh_trace_count += 1
+                    if wait_left_times:
+                        fig_wfh.add_trace(
+                            go.Box(
+                                x=[subj] * len(wait_left_times),
+                                y=wait_left_times,
+                                name="Left",
+                                marker_color="royalblue",
+                                legendgroup="choice-left",
+                                showlegend=i == 0,
+                                boxmean=True,
+                                offsetgroup="left",
+                                visible=False,
+                            )
+                        )
+                        wfh_split_idx.append(wfh_trace_count)
+                        wfh_trace_count += 1
+                    if wait_right_times:
+                        fig_wfh.add_trace(
+                            go.Box(
+                                x=[subj] * len(wait_right_times),
+                                y=wait_right_times,
+                                name="Right",
+                                marker_color="darkorange",
+                                legendgroup="choice-right",
+                                showlegend=i == 0,
+                                boxmean=True,
+                                offsetgroup="right",
+                                visible=False,
+                            )
+                        )
+                        wfh_split_idx.append(wfh_trace_count)
+                        wfh_trace_count += 1
                 else:
                     fig_wfh.add_trace(
                         go.Histogram(
@@ -1051,8 +1317,39 @@ def create_app() -> Dash:
                             marker_color=c,
                             showlegend=False,
                             opacity=0.8,
+                            visible=True,
                         )
                     )
+                    wfh_combined_idx.append(wfh_trace_count)
+                    wfh_trace_count += 1
+                    if wait_left_times:
+                        fig_wfh.add_trace(
+                            go.Histogram(
+                                x=wait_left_times,
+                                nbinsx=30,
+                                name="Left",
+                                marker_color="royalblue",
+                                showlegend=True,
+                                opacity=0.65,
+                                visible=False,
+                            )
+                        )
+                        wfh_split_idx.append(wfh_trace_count)
+                        wfh_trace_count += 1
+                    if wait_right_times:
+                        fig_wfh.add_trace(
+                            go.Histogram(
+                                x=wait_right_times,
+                                nbinsx=30,
+                                name="Right",
+                                marker_color="darkorange",
+                                showlegend=True,
+                                opacity=0.65,
+                                visible=False,
+                            )
+                        )
+                        wfh_split_idx.append(wfh_trace_count)
+                        wfh_trace_count += 1
                     if sm["wait_times"]:
                         med_val = np.median(sm["wait_times"])
                         fig_wfh.add_vline(
@@ -1159,6 +1456,10 @@ def create_app() -> Dash:
                     rt_trace_count += 1
 
             iti_vals = sm.get("iti_times", [])
+            iti_after_correct = sm.get("iti_times_after_correct", [])
+            iti_after_incorrect = sm.get("iti_times_after_incorrect", [])
+            iti_after_ew = sm.get("iti_times_after_ew", [])
+            iti_after_no_choice = sm.get("iti_times_after_no_choice", [])
             if iti_vals:
                 if multi_col:
                     fig_itid.add_trace(
@@ -1169,8 +1470,48 @@ def create_app() -> Dash:
                             legendgroup=grp,
                             showlegend=False,
                             boxmean=True,
+                            visible=True,
                         )
                     )
+                    itid_combined_idx.append(itid_trace_count)
+                    itid_trace_count += 1
+                    for label, vals, color, group in [
+                        (
+                            "After Correct",
+                            iti_after_correct,
+                            "mediumseagreen",
+                            "iti-correct",
+                        ),
+                        (
+                            "After Incorrect",
+                            iti_after_incorrect,
+                            "tomato",
+                            "iti-incorrect",
+                        ),
+                        ("After EW", iti_after_ew, "slategray", "iti-ew"),
+                        (
+                            "After No Choice",
+                            iti_after_no_choice,
+                            "#6b7280",
+                            "iti-no-choice",
+                        ),
+                    ]:
+                        if vals:
+                            fig_itid.add_trace(
+                                go.Box(
+                                    x=[subj] * len(vals),
+                                    y=vals,
+                                    name=label,
+                                    marker_color=color,
+                                    legendgroup=group,
+                                    showlegend=i == 0,
+                                    boxmean=True,
+                                    offsetgroup=group,
+                                    visible=False,
+                                )
+                            )
+                            itid_split_idx.append(itid_trace_count)
+                            itid_trace_count += 1
                 else:
                     fig_itid.add_trace(
                         go.Histogram(
@@ -1180,8 +1521,31 @@ def create_app() -> Dash:
                             marker_color=c,
                             showlegend=False,
                             opacity=0.8,
+                            visible=True,
                         )
                     )
+                    itid_combined_idx.append(itid_trace_count)
+                    itid_trace_count += 1
+                    for label, vals, color in [
+                        ("After Correct", iti_after_correct, "mediumseagreen"),
+                        ("After Incorrect", iti_after_incorrect, "tomato"),
+                        ("After EW", iti_after_ew, "slategray"),
+                        ("After No Choice", iti_after_no_choice, "#6b7280"),
+                    ]:
+                        if vals:
+                            fig_itid.add_trace(
+                                go.Histogram(
+                                    x=vals,
+                                    nbinsx=30,
+                                    name=label,
+                                    marker_color=color,
+                                    showlegend=True,
+                                    opacity=0.65,
+                                    visible=False,
+                                )
+                            )
+                            itid_split_idx.append(itid_trace_count)
+                            itid_trace_count += 1
                     med_val = np.median(iti_vals)
                     fig_itid.add_vline(
                         x=med_val,
@@ -1342,14 +1706,67 @@ def create_app() -> Dash:
             yaxis_title="time (s)",
             yaxis_range=wait_delta_y_range,
         )
+        if wdl_combined_idx and wdl_split_idx:
+            off_visible = [idx in wdl_combined_idx for idx in range(wdl_trace_count)]
+            on_visible = [idx in wdl_split_idx for idx in range(wdl_trace_count)]
+            fig_wdl.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        showactive=True,
+                        buttons=[
+                            dict(
+                                label="Choice",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
+                            )
+                        ],
+                    )
+                ]
+            )
         if multi:
-            _layout(fig_wdh, title="Post-Go Center Dwell Dist.", yaxis_title="time (s)")
+            _layout(
+                fig_wdh,
+                title="Post-Go Center Dwell Dist.",
+                yaxis_title="time (s)",
+                boxmode="group",
+            )
         else:
             _layout(
                 fig_wdh,
                 title="Post-Go Center Dwell Dist.",
                 xaxis_title="time (s)",
                 yaxis_title="count",
+            )
+        if wdh_combined_idx and wdh_split_idx:
+            off_visible = [idx in wdh_combined_idx for idx in range(wdh_trace_count)]
+            on_visible = [idx in wdh_split_idx for idx in range(wdh_trace_count)]
+            fig_wdh.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        showactive=True,
+                        buttons=[
+                            dict(
+                                label="Choice",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
+                            )
+                        ],
+                    )
+                ]
             )
         _layout(
             fig_wfl,
@@ -1358,14 +1775,67 @@ def create_app() -> Dash:
             yaxis_title="time (s)",
             yaxis_range=wait_floor_y_range,
         )
+        if wfl_combined_idx and wfl_split_idx:
+            off_visible = [idx in wfl_combined_idx for idx in range(wfl_trace_count)]
+            on_visible = [idx in wfl_split_idx for idx in range(wfl_trace_count)]
+            fig_wfl.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        showactive=True,
+                        buttons=[
+                            dict(
+                                label="Choice",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
+                            )
+                        ],
+                    )
+                ]
+            )
         if multi:
-            _layout(fig_wfh, title="Wait Floor Dist.", yaxis_title="time (s)")
+            _layout(
+                fig_wfh,
+                title="Wait Floor Dist.",
+                yaxis_title="time (s)",
+                boxmode="group",
+            )
         else:
             _layout(
                 fig_wfh,
                 title="Wait Floor Dist.",
                 xaxis_title="time (s)",
                 yaxis_title="count",
+            )
+        if wfh_combined_idx and wfh_split_idx:
+            off_visible = [idx in wfh_combined_idx for idx in range(wfh_trace_count)]
+            on_visible = [idx in wfh_split_idx for idx in range(wfh_trace_count)]
+            fig_wfh.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        showactive=True,
+                        buttons=[
+                            dict(
+                                label="Choice",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
+                            )
+                        ],
+                    )
+                ]
             )
 
         # Row 4
@@ -1381,16 +1851,13 @@ def create_app() -> Dash:
                         y=1.18,
                         xanchor="right",
                         yanchor="top",
+                        showactive=True,
                         buttons=[
                             dict(
-                                label="Split: Off",
-                                method="restyle",
-                                args=[{"visible": off_visible}],
-                            ),
-                            dict(
-                                label="Split: On",
+                                label="Outcome",
                                 method="restyle",
                                 args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
                             ),
                         ],
                     )
@@ -1412,13 +1879,37 @@ def create_app() -> Dash:
                 yaxis_title="count",
             )
         if multi_col:
-            _layout(fig_itid, title="ITIs", yaxis_title="time (s)")
+            _layout(fig_itid, title="ITIs", yaxis_title="time (s)", boxmode="group")
         else:
             _layout(
                 fig_itid,
                 title="ITIs",
                 xaxis_title="time (s)",
                 yaxis_title="count",
+            )
+        if itid_combined_idx and itid_split_idx:
+            off_visible = [idx in itid_combined_idx for idx in range(itid_trace_count)]
+            on_visible = [idx in itid_split_idx for idx in range(itid_trace_count)]
+            fig_itid.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        showactive=True,
+                        buttons=[
+                            dict(
+                                label="Outcome",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                                args2=[{"visible": off_visible}],
+                            )
+                        ],
+                    )
+                ]
             )
         _layout(
             fig_tct,

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -1361,8 +1361,8 @@ def create_app() -> Dash:
 
             # --- Row 4: Response Time ---
             response_times = sm.get("response_times", [])
-            response_correct = sm.get("response_times_correct", [])
-            response_incorrect = sm.get("response_times_incorrect", [])
+            response_left = sm.get("response_times_left", [])
+            response_right = sm.get("response_times_right", [])
             if multi_col:
                 if response_times:
                     fig_rt.add_trace(
@@ -1379,33 +1379,33 @@ def create_app() -> Dash:
                     )
                     rt_combined_idx.append(rt_trace_count)
                     rt_trace_count += 1
-                if response_correct:
+                if response_left:
                     fig_rt.add_trace(
                         go.Box(
-                            x=[subj] * len(response_correct),
-                            y=response_correct,
-                            name="Correct",
-                            legendgroup="rt-correct",
+                            x=[subj] * len(response_left),
+                            y=response_left,
+                            name="Left",
+                            legendgroup="rt-left",
                             showlegend=i == 0,
-                            marker_color="mediumseagreen",
+                            marker_color="royalblue",
                             boxmean=True,
-                            offsetgroup="correct",
+                            offsetgroup="left",
                             visible=False,
                         )
                     )
                     rt_split_idx.append(rt_trace_count)
                     rt_trace_count += 1
-                if response_incorrect:
+                if response_right:
                     fig_rt.add_trace(
                         go.Box(
-                            x=[subj] * len(response_incorrect),
-                            y=response_incorrect,
-                            name="Incorrect",
-                            legendgroup="rt-incorrect",
+                            x=[subj] * len(response_right),
+                            y=response_right,
+                            name="Right",
+                            legendgroup="rt-right",
                             showlegend=i == 0,
-                            marker_color="tomato",
+                            marker_color="darkorange",
                             boxmean=True,
-                            offsetgroup="incorrect",
+                            offsetgroup="right",
                             visible=False,
                         )
                     )
@@ -1417,7 +1417,7 @@ def create_app() -> Dash:
                         go.Histogram(
                             x=response_times,
                             nbinsx=30,
-                            name="All outcomes",
+                            name="All choices",
                             marker_color=c,
                             showlegend=False,
                             opacity=0.8,
@@ -1426,13 +1426,13 @@ def create_app() -> Dash:
                     )
                     rt_combined_idx.append(rt_trace_count)
                     rt_trace_count += 1
-                if response_correct:
+                if response_left:
                     fig_rt.add_trace(
                         go.Histogram(
-                            x=response_correct,
+                            x=response_left,
                             nbinsx=30,
-                            name="Correct",
-                            marker_color="mediumseagreen",
+                            name="Left",
+                            marker_color="royalblue",
                             showlegend=True,
                             opacity=0.65,
                             visible=False,
@@ -1440,13 +1440,13 @@ def create_app() -> Dash:
                     )
                     rt_split_idx.append(rt_trace_count)
                     rt_trace_count += 1
-                if response_incorrect:
+                if response_right:
                     fig_rt.add_trace(
                         go.Histogram(
-                            x=response_incorrect,
+                            x=response_right,
                             nbinsx=30,
-                            name="Incorrect",
-                            marker_color="tomato",
+                            name="Right",
+                            marker_color="darkorange",
                             showlegend=True,
                             opacity=0.65,
                             visible=False,
@@ -1854,7 +1854,7 @@ def create_app() -> Dash:
                         showactive=True,
                         buttons=[
                             dict(
-                                label="Outcome",
+                                label="Choice",
                                 method="restyle",
                                 args=[{"visible": on_visible}],
                                 args2=[{"visible": off_visible}],

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -399,8 +399,8 @@ def create_app() -> Dash:
             _row("init-line", "wait-delta-line", "wait-floor-line"),
             # Row 3: Timing — distributions for each column above
             _row("init-hist", "wait-delta-hist", "wait-floor-hist"),
-            # Row 4: Gap-time + session pacing
-            _row("gap-time", "iti-dist", "trial-count-time"),
+            # Row 4: Response-time + session pacing
+            _row("response-time", "iti-dist", "trial-count-time"),
         ]
     )
 
@@ -677,7 +677,7 @@ def create_app() -> Dash:
         Output("wait-delta-hist", "figure"),
         Output("wait-floor-line", "figure"),
         Output("wait-floor-hist", "figure"),
-        Output("gap-time", "figure"),
+        Output("response-time", "figure"),
         Output("iti-dist", "figure"),
         Output("trial-count-time", "figure"),
         Input("subjects-recent", "value"),
@@ -702,7 +702,7 @@ def create_app() -> Dash:
 
         Callback Outputs:
             Thirteen figures for outcomes, psychometric/chronometric, performance,
-            initiation, post-go center dwell, wait-floor, gap-time, and session
+            initiation, post-go center dwell, wait-floor, response-time, and session
             pacing views.
 
         Args:
@@ -741,12 +741,15 @@ def create_app() -> Dash:
         fig_il, fig_ih = go.Figure(), go.Figure()
         fig_wdl, fig_wdh = go.Figure(), go.Figure()
         fig_wfl, fig_wfh = go.Figure(), go.Figure()
-        fig_gt = go.Figure()
+        fig_rt = go.Figure()
         fig_itid = go.Figure()
         fig_tct = go.Figure()
         init_y_vals: list[float] = []
         wait_delta_y_vals: list[float] = []
         wait_floor_y_vals: list[float] = []
+        rt_combined_idx: list[int] = []
+        rt_split_idx: list[int] = []
+        rt_trace_count = 0
 
         # Collect outcome totals for multi-subject horizontal bars
         multi_outcome_data = []
@@ -1059,67 +1062,101 @@ def create_app() -> Dash:
                             line_width=1.5,
                         )
 
-            # --- Row 4: Gap Time by Outcome ---
-            gap_correct = sm.get("gap_times_correct", [])
-            gap_incorrect = sm.get("gap_times_incorrect", [])
+            # --- Row 4: Response Time ---
+            response_times = sm.get("response_times", [])
+            response_correct = sm.get("response_times_correct", [])
+            response_incorrect = sm.get("response_times_incorrect", [])
             if multi_col:
-                if gap_correct:
-                    fig_gt.add_trace(
-                        go.Violin(
-                            x=[subj] * len(gap_correct),
-                            y=gap_correct,
+                if response_times:
+                    fig_rt.add_trace(
+                        go.Box(
+                            x=[subj] * len(response_times),
+                            y=response_times,
+                            name=subj,
+                            legendgroup=grp,
+                            showlegend=False,
+                            marker_color=c,
+                            boxmean=True,
+                            visible=True,
+                        )
+                    )
+                    rt_combined_idx.append(rt_trace_count)
+                    rt_trace_count += 1
+                if response_correct:
+                    fig_rt.add_trace(
+                        go.Box(
+                            x=[subj] * len(response_correct),
+                            y=response_correct,
                             name="Correct",
-                            legendgroup="gap-correct",
+                            legendgroup="rt-correct",
                             showlegend=i == 0,
-                            line_color="mediumseagreen",
-                            side="negative",
-                            meanline_visible=True,
-                            points=False,
-                            scalegroup=subj,
+                            marker_color="mediumseagreen",
+                            boxmean=True,
+                            offsetgroup="correct",
+                            visible=False,
                         )
                     )
-                if gap_incorrect:
-                    fig_gt.add_trace(
-                        go.Violin(
-                            x=[subj] * len(gap_incorrect),
-                            y=gap_incorrect,
+                    rt_split_idx.append(rt_trace_count)
+                    rt_trace_count += 1
+                if response_incorrect:
+                    fig_rt.add_trace(
+                        go.Box(
+                            x=[subj] * len(response_incorrect),
+                            y=response_incorrect,
                             name="Incorrect",
-                            legendgroup="gap-incorrect",
+                            legendgroup="rt-incorrect",
                             showlegend=i == 0,
-                            line_color="tomato",
-                            side="positive",
-                            meanline_visible=True,
-                            points=False,
-                            scalegroup=subj,
+                            marker_color="tomato",
+                            boxmean=True,
+                            offsetgroup="incorrect",
+                            visible=False,
                         )
                     )
+                    rt_split_idx.append(rt_trace_count)
+                    rt_trace_count += 1
             else:
-                if gap_correct:
-                    fig_gt.add_trace(
-                        go.Violin(
-                            x=["Correct"] * len(gap_correct),
-                            y=gap_correct,
+                if response_times:
+                    fig_rt.add_trace(
+                        go.Histogram(
+                            x=response_times,
+                            nbinsx=30,
+                            name="All outcomes",
+                            marker_color=c,
+                            showlegend=False,
+                            opacity=0.8,
+                            visible=True,
+                        )
+                    )
+                    rt_combined_idx.append(rt_trace_count)
+                    rt_trace_count += 1
+                if response_correct:
+                    fig_rt.add_trace(
+                        go.Histogram(
+                            x=response_correct,
+                            nbinsx=30,
                             name="Correct",
-                            legendgroup="gap-correct",
+                            marker_color="mediumseagreen",
                             showlegend=True,
-                            line_color="mediumseagreen",
-                            meanline_visible=True,
-                            points=False,
+                            opacity=0.65,
+                            visible=False,
                         )
                     )
-                if gap_incorrect:
-                    fig_gt.add_trace(
-                        go.Violin(
-                            x=["Incorrect"] * len(gap_incorrect),
-                            y=gap_incorrect,
+                    rt_split_idx.append(rt_trace_count)
+                    rt_trace_count += 1
+                if response_incorrect:
+                    fig_rt.add_trace(
+                        go.Histogram(
+                            x=response_incorrect,
+                            nbinsx=30,
                             name="Incorrect",
-                            legendgroup="gap-incorrect",
+                            marker_color="tomato",
                             showlegend=True,
-                            line_color="tomato",
-                            meanline_visible=True,
-                            points=False,
+                            opacity=0.65,
+                            visible=False,
                         )
                     )
+                    rt_split_idx.append(rt_trace_count)
+                    rt_trace_count += 1
 
             iti_vals = sm.get("iti_times", [])
             if iti_vals:
@@ -1332,12 +1369,48 @@ def create_app() -> Dash:
             )
 
         # Row 4
-        _layout(
-            fig_gt,
-            title="Gap time by outcome",
-            xaxis_title="subject" if multi_col else "outcome",
-            yaxis_title="time (s)",
-        )
+        if rt_combined_idx and rt_split_idx:
+            off_visible = [idx in rt_combined_idx for idx in range(rt_trace_count)]
+            on_visible = [idx in rt_split_idx for idx in range(rt_trace_count)]
+            fig_rt.update_layout(
+                updatemenus=[
+                    dict(
+                        type="buttons",
+                        direction="left",
+                        x=1.0,
+                        y=1.18,
+                        xanchor="right",
+                        yanchor="top",
+                        buttons=[
+                            dict(
+                                label="Split: Off",
+                                method="restyle",
+                                args=[{"visible": off_visible}],
+                            ),
+                            dict(
+                                label="Split: On",
+                                method="restyle",
+                                args=[{"visible": on_visible}],
+                            ),
+                        ],
+                    )
+                ]
+            )
+        if multi_col:
+            _layout(
+                fig_rt,
+                title="Response Time",
+                xaxis_title="subject",
+                yaxis_title="time (s)",
+                boxmode="group",
+            )
+        else:
+            _layout(
+                fig_rt,
+                title="Response Time",
+                xaxis_title="time (s)",
+                yaxis_title="count",
+            )
         if multi_col:
             _layout(fig_itid, title="ITIs", yaxis_title="time (s)")
         else:
@@ -1366,7 +1439,7 @@ def create_app() -> Dash:
             fig_wdh,
             fig_wfl,
             fig_wfh,
-            fig_gt,
+            fig_rt,
             fig_itid,
             fig_tct,
         )

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -611,6 +611,36 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_roll_x.append(int(np.mean(rt_trial_nums[start : start + win])))
         rt_roll_y.append(float(np.median(rt_vals[start : start + win])))
 
+    # Gap times: response - react, split by outcome for violin rendering.
+    gap_raw = trials["t_response"].to_numpy() - trials["t_react"].to_numpy()
+    rewarded = trials["rewarded"].to_numpy()
+    punished = trials["punished"].to_numpy()
+    gap_mask = (
+        np.isfinite(gap_raw) & (gap_raw > 0) & (gap_raw < 5) & (trials.response != 0)
+    )
+    gap_times = gap_raw[gap_mask]
+    gap_correct = gap_raw[gap_mask & (rewarded == 1)]
+    gap_incorrect = gap_raw[gap_mask & (punished == 1)]
+
+    # Inter-trial intervals from consecutive trial start times.
+    start_times = trials["t_start"].to_numpy()
+    start_times = start_times[np.isfinite(start_times)]
+    iti_vals = np.diff(start_times) if start_times.size > 1 else np.array([])
+    iti_vals = iti_vals[(iti_vals > 0) & (iti_vals < 30)]
+
+    # Trial-count histogram across session time (5-minute bins from first trial).
+    trial_count_bin_size_min = 5.0
+    if start_times.size:
+        elapsed_min = (start_times - start_times[0]) / 60.0
+        max_elapsed = float(np.max(elapsed_min)) if elapsed_min.size else 0.0
+        max_edge = max(trial_count_bin_size_min, max_elapsed + trial_count_bin_size_min)
+        bin_edges = np.arange(0.0, max_edge + 1e-9, trial_count_bin_size_min)
+        trial_count_vals, _ = np.histogram(elapsed_min, bins=bin_edges)
+        trial_count_x = (bin_edges[:-1] + (trial_count_bin_size_min / 2.0)).tolist()
+    else:
+        trial_count_vals = np.array([])
+        trial_count_x = []
+
     # Rolling median of wait delta (20-trial window)
     wait_delta_x, wait_delta_y = [], []
     for start in range(0, len(wait_delta) - win + 1, 5):
@@ -647,6 +677,12 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_vals=rt_vals.tolist(),
         rt_roll_x=rt_roll_x,
         rt_roll_y=rt_roll_y,
+        gap_times=gap_times.tolist(),
+        gap_times_correct=gap_correct.tolist(),
+        gap_times_incorrect=gap_incorrect.tolist(),
+        iti_times=iti_vals.tolist(),
+        trial_count_x=trial_count_x,
+        trial_count_y=trial_count_vals.astype(float).tolist(),
         init_times=init_vals.tolist(),
         init_trial_nums=init_trial_nums.tolist(),
         init_roll_x=init_roll_x,

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -611,16 +611,19 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_roll_x.append(int(np.mean(rt_trial_nums[start : start + win])))
         rt_roll_y.append(float(np.median(rt_vals[start : start + win])))
 
-    # Gap times: response - react, split by outcome for violin rendering.
-    gap_raw = trials["t_response"].to_numpy() - trials["t_react"].to_numpy()
+    # Response times (movement time): response - react, split by outcome.
+    response_raw = trials["t_response"].to_numpy() - trials["t_react"].to_numpy()
     rewarded = trials["rewarded"].to_numpy()
     punished = trials["punished"].to_numpy()
-    gap_mask = (
-        np.isfinite(gap_raw) & (gap_raw > 0) & (gap_raw < 5) & (trials.response != 0)
+    response_mask = (
+        np.isfinite(response_raw)
+        & (response_raw > 0)
+        & (response_raw < 5)
+        & (trials.response != 0)
     )
-    gap_times = gap_raw[gap_mask]
-    gap_correct = gap_raw[gap_mask & (rewarded == 1)]
-    gap_incorrect = gap_raw[gap_mask & (punished == 1)]
+    response_times = response_raw[response_mask]
+    response_correct = response_raw[response_mask & (rewarded == 1)]
+    response_incorrect = response_raw[response_mask & (punished == 1)]
 
     # Inter-trial intervals from consecutive trial start times.
     start_times = trials["t_start"].to_numpy()
@@ -677,9 +680,9 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_vals=rt_vals.tolist(),
         rt_roll_x=rt_roll_x,
         rt_roll_y=rt_roll_y,
-        gap_times=gap_times.tolist(),
-        gap_times_correct=gap_correct.tolist(),
-        gap_times_incorrect=gap_incorrect.tolist(),
+        response_times=response_times.tolist(),
+        response_times_correct=response_correct.tolist(),
+        response_times_incorrect=response_incorrect.tolist(),
         iti_times=iti_vals.tolist(),
         trial_count_x=trial_count_x,
         trial_count_y=trial_count_vals.astype(float).tolist(),

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -613,25 +613,83 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
 
     # Response times (movement time): response - react, split by outcome.
     response_raw = trials["t_response"].to_numpy() - trials["t_react"].to_numpy()
+    response_vals = trials["response"].to_numpy()
     rewarded = trials["rewarded"].to_numpy()
     punished = trials["punished"].to_numpy()
+    early_withdrawal = trials["early_withdrawal"].to_numpy()
     response_mask = (
         np.isfinite(response_raw)
         & (response_raw > 0)
         & (response_raw < 5)
-        & (trials.response != 0)
+        & (response_vals != 0)
     )
     response_times = response_raw[response_mask]
     response_correct = response_raw[response_mask & (rewarded == 1)]
     response_incorrect = response_raw[response_mask & (punished == 1)]
 
-    # Inter-trial intervals from consecutive trial start times.
-    start_times = trials["t_start"].to_numpy()
-    start_times = start_times[np.isfinite(start_times)]
-    iti_vals = np.diff(start_times) if start_times.size > 1 else np.array([])
-    iti_vals = iti_vals[(iti_vals > 0) & (iti_vals < 30)]
+    # Left/right choice splits for post-go center dwell and wait floor.
+    wait_choice = response_vals[wait_mask]
+    left_choice_mask = wait_choice == -1
+    right_choice_mask = wait_choice == 1
+    wait_delta_left = wait_delta[left_choice_mask]
+    wait_delta_right = wait_delta[right_choice_mask]
+    wait_left = wait_actual[left_choice_mask]
+    wait_right = wait_actual[right_choice_mask]
+    wait_trial_nums_left = wait_trial_nums[left_choice_mask]
+    wait_trial_nums_right = wait_trial_nums[right_choice_mask]
+
+    # Rolling helper used for split traces.
+    def _rolling_median(
+        x_vals: np.ndarray, y_vals: np.ndarray
+    ) -> tuple[list[int], list[float]]:
+        roll_x: list[int] = []
+        roll_y: list[float] = []
+        for start in range(0, len(y_vals) - win + 1, 5):
+            roll_x.append(int(np.mean(x_vals[start : start + win])))
+            roll_y.append(float(np.median(y_vals[start : start + win])))
+        return roll_x, roll_y
+
+    wait_delta_left_roll_x, wait_delta_left_roll_y = _rolling_median(
+        wait_trial_nums_left, wait_delta_left
+    )
+    wait_delta_right_roll_x, wait_delta_right_roll_y = _rolling_median(
+        wait_trial_nums_right, wait_delta_right
+    )
+    wait_left_roll_x, wait_left_roll_y = _rolling_median(
+        wait_trial_nums_left, wait_left
+    )
+    wait_right_roll_x, wait_right_roll_y = _rolling_median(
+        wait_trial_nums_right, wait_right
+    )
+
+    # Inter-trial intervals from consecutive trial starts, split by preceding outcome.
+    start_times_all = trials["t_start"].to_numpy()
+    iti_all: list[float] = []
+    iti_after_correct: list[float] = []
+    iti_after_incorrect: list[float] = []
+    iti_after_ew: list[float] = []
+    iti_after_no_choice: list[float] = []
+    for i in range(len(start_times_all) - 1):
+        start_prev = start_times_all[i]
+        start_next = start_times_all[i + 1]
+        if not (np.isfinite(start_prev) and np.isfinite(start_next)):
+            continue
+        iti = float(start_next - start_prev)
+        if not (0 < iti < 30):
+            continue
+        iti_all.append(iti)
+        if rewarded[i] == 1:
+            iti_after_correct.append(iti)
+        elif punished[i] == 1:
+            iti_after_incorrect.append(iti)
+        elif early_withdrawal[i] == 1:
+            iti_after_ew.append(iti)
+        else:
+            iti_after_no_choice.append(iti)
+    iti_vals = np.asarray(iti_all, dtype=float)
 
     # Trial-count histogram across session time (5-minute bins from first trial).
+    start_times = start_times_all[np.isfinite(start_times_all)]
     trial_count_bin_size_min = 5.0
     if start_times.size:
         elapsed_min = (start_times - start_times[0]) / 60.0
@@ -684,6 +742,10 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         response_times_correct=response_correct.tolist(),
         response_times_incorrect=response_incorrect.tolist(),
         iti_times=iti_vals.tolist(),
+        iti_times_after_correct=iti_after_correct,
+        iti_times_after_incorrect=iti_after_incorrect,
+        iti_times_after_ew=iti_after_ew,
+        iti_times_after_no_choice=iti_after_no_choice,
         trial_count_x=trial_count_x,
         trial_count_y=trial_count_vals.astype(float).tolist(),
         init_times=init_vals.tolist(),
@@ -693,11 +755,25 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         wait_times=wait_actual.tolist(),
         wait_min_times=wait_min.tolist(),
         wait_delta_times=wait_delta.tolist(),
+        wait_delta_left_times=wait_delta_left.tolist(),
+        wait_delta_right_times=wait_delta_right.tolist(),
         wait_trial_nums=wait_trial_nums.tolist(),
+        wait_trial_nums_left=wait_trial_nums_left.tolist(),
+        wait_trial_nums_right=wait_trial_nums_right.tolist(),
         wait_delta_x=wait_delta_x,
         wait_delta_y=wait_delta_y,
+        wait_delta_left_x=wait_delta_left_roll_x,
+        wait_delta_left_y=wait_delta_left_roll_y,
+        wait_delta_right_x=wait_delta_right_roll_x,
+        wait_delta_right_y=wait_delta_right_roll_y,
         wait_roll_x=wait_roll_x,
         wait_roll_y=wait_roll_y,
+        wait_times_left=wait_left.tolist(),
+        wait_times_right=wait_right.tolist(),
+        wait_left_x=wait_left_roll_x,
+        wait_left_y=wait_left_roll_y,
+        wait_right_x=wait_right_roll_x,
+        wait_right_y=wait_right_roll_y,
         slide_x=slide_x,  # rolling performance x
         slide_y=slide_y,  # rolling performance y
         ew_roll_x=ew_roll_x,  # rolling EW x

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -611,7 +611,7 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_roll_x.append(int(np.mean(rt_trial_nums[start : start + win])))
         rt_roll_y.append(float(np.median(rt_vals[start : start + win])))
 
-    # Response times (movement time): response - react, split by outcome.
+    # Response times (movement time): response - react, split by choice.
     response_raw = trials["t_response"].to_numpy() - trials["t_react"].to_numpy()
     response_vals = trials["response"].to_numpy()
     rewarded = trials["rewarded"].to_numpy()
@@ -624,8 +624,8 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         & (response_vals != 0)
     )
     response_times = response_raw[response_mask]
-    response_correct = response_raw[response_mask & (rewarded == 1)]
-    response_incorrect = response_raw[response_mask & (punished == 1)]
+    response_left = response_raw[response_mask & (response_vals == -1)]
+    response_right = response_raw[response_mask & (response_vals == 1)]
 
     # Left/right choice splits for post-go center dwell and wait floor.
     wait_choice = response_vals[wait_mask]
@@ -739,8 +739,8 @@ def session_metrics(subject: str, session_name: str) -> dict | None:
         rt_roll_x=rt_roll_x,
         rt_roll_y=rt_roll_y,
         response_times=response_times.tolist(),
-        response_times_correct=response_correct.tolist(),
-        response_times_incorrect=response_incorrect.tolist(),
+        response_times_left=response_left.tolist(),
+        response_times_right=response_right.tolist(),
         iti_times=iti_vals.tolist(),
         iti_times_after_correct=iti_after_correct,
         iti_times_after_incorrect=iti_after_incorrect,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -283,13 +283,27 @@ class TestAppUtilities(unittest.TestCase):
             "init_times": [],
             "init_roll_x": [],
             "init_roll_y": [],
-            "wait_delta_times": [],
-            "wait_trial_nums": [],
+            "wait_delta_times": [0.2, 0.3],
+            "wait_trial_nums": [1, 2],
             "wait_delta_x": [],
             "wait_delta_y": [],
-            "wait_times": [],
+            "wait_delta_left_times": [0.12, 0.15],
+            "wait_delta_right_times": [0.2, 0.24],
+            "wait_trial_nums_left": [1, 3],
+            "wait_trial_nums_right": [2, 4],
+            "wait_delta_left_x": [],
+            "wait_delta_left_y": [],
+            "wait_delta_right_x": [],
+            "wait_delta_right_y": [],
+            "wait_times": [0.5, 0.6],
             "wait_roll_x": [],
             "wait_roll_y": [],
+            "wait_times_left": [0.5],
+            "wait_times_right": [0.6],
+            "wait_left_x": [],
+            "wait_left_y": [],
+            "wait_right_x": [],
+            "wait_right_y": [],
             "rts": [],
             "rt_trial_nums": [],
             "rt_vals": [],
@@ -299,6 +313,10 @@ class TestAppUtilities(unittest.TestCase):
             "response_times_correct": [0.2, 0.25],
             "response_times_incorrect": [0.4],
             "iti_times": [0.8, 1.1, 1.0],
+            "iti_times_after_correct": [0.8],
+            "iti_times_after_incorrect": [1.1],
+            "iti_times_after_ew": [1.0],
+            "iti_times_after_no_choice": [0.9],
             "trial_count_x": [2.5, 7.5],
             "trial_count_y": [20.0, 18.0],
         }
@@ -317,6 +335,10 @@ class TestAppUtilities(unittest.TestCase):
         self.assertIn("yaxis_range", figures[4].layout)  # init-line
         self.assertIn("yaxis_range", figures[6].layout)  # wait-delta-line
         self.assertIn("yaxis_range", figures[8].layout)  # wait-floor-line
+        self.assertIn("updatemenus", figures[6].layout)  # dwell choice toggle
+        self.assertIn("updatemenus", figures[8].layout)  # wait-floor choice toggle
+        self.assertIn("updatemenus", figures[10].layout)  # response outcome toggle
+        self.assertIn("updatemenus", figures[11].layout)  # iti outcome toggle
 
     def test_update_multi_returns_empty_figures_when_no_subjects(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -310,8 +310,8 @@ class TestAppUtilities(unittest.TestCase):
             "rt_roll_x": [],
             "rt_roll_y": [],
             "response_times": [0.2, 0.25, 0.4],
-            "response_times_correct": [0.2, 0.25],
-            "response_times_incorrect": [0.4],
+            "response_times_left": [0.2, 0.25],
+            "response_times_right": [0.4],
             "iti_times": [0.8, 1.1, 1.0],
             "iti_times_after_correct": [0.8],
             "iti_times_after_incorrect": [1.1],
@@ -337,7 +337,10 @@ class TestAppUtilities(unittest.TestCase):
         self.assertIn("yaxis_range", figures[8].layout)  # wait-floor-line
         self.assertIn("updatemenus", figures[6].layout)  # dwell choice toggle
         self.assertIn("updatemenus", figures[8].layout)  # wait-floor choice toggle
-        self.assertIn("updatemenus", figures[10].layout)  # response outcome toggle
+        self.assertIn("updatemenus", figures[10].layout)  # response choice toggle
+        self.assertEqual(
+            figures[10].layout["updatemenus"][0]["buttons"][0]["label"], "Choice"
+        )
         self.assertIn("updatemenus", figures[11].layout)  # iti outcome toggle
 
     def test_update_multi_returns_empty_figures_when_no_subjects(self) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -249,10 +249,73 @@ class TestAppUtilities(unittest.TestCase):
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
             figures = update_single(["subject-a"], [], None, 0, None)
 
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )
+
+    def test_update_single_builds_gap_time_figure(self) -> None:
+        app = self.appmod.create_app()
+        update_single = app.callbacks["_update_single"]
+
+        # Minimal trace factories so fake graph_objects supports callback execution.
+        trace_names = ("Bar", "Scatter", "Scattergl", "Box", "Histogram", "Violin")
+        for trace_name in trace_names:
+            setattr(
+                self.appmod.go,
+                trace_name,
+                lambda **kw: {"trace": "generic", "kwargs": kw},
+            )
+
+        metrics = {
+            "stims": [0.0],
+            "n_correct": [1],
+            "n_incorrect": [0],
+            "n_ew": [0],
+            "n_no_choice": [0],
+            "p_right": [0.5],
+            "median_rt": [0.2],
+            "slide_x": [],
+            "slide_y": [],
+            "ew_roll_x": [],
+            "ew_roll_y": [],
+            "init_trial_nums": [],
+            "init_times": [],
+            "init_roll_x": [],
+            "init_roll_y": [],
+            "wait_delta_times": [],
+            "wait_trial_nums": [],
+            "wait_delta_x": [],
+            "wait_delta_y": [],
+            "wait_times": [],
+            "wait_roll_x": [],
+            "wait_roll_y": [],
+            "rts": [],
+            "rt_trial_nums": [],
+            "rt_vals": [],
+            "rt_roll_x": [],
+            "rt_roll_y": [],
+            "gap_times_correct": [0.2, 0.25],
+            "gap_times_incorrect": [0.4],
+            "iti_times": [0.8, 1.1, 1.0],
+            "trial_count_x": [2.5, 7.5],
+            "trial_count_y": [20.0, 18.0],
+        }
+
+        with (
+            mock.patch.object(
+                self.appmod, "get_sessions", return_value=["20260101_010101"]
+            ),
+            mock.patch.object(self.appmod, "session_metrics", return_value=metrics),
+        ):
+            figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
+
+        self.assertEqual(len(figures), 13)
+        self.assertEqual(figures[10].layout["title"]["text"], "Gap time by outcome")
+        self.assertEqual(len(figures[10].traces), 2)
+        self.assertIn("yaxis_range", figures[4].layout)  # init-line
+        self.assertIn("yaxis_range", figures[6].layout)  # wait-delta-line
+        self.assertIn("yaxis_range", figures[8].layout)  # wait-floor-line
 
     def test_update_multi_returns_empty_figures_when_no_subjects(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -254,7 +254,7 @@ class TestAppUtilities(unittest.TestCase):
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )
 
-    def test_update_single_builds_gap_time_figure(self) -> None:
+    def test_update_single_builds_response_time_figure(self) -> None:
         app = self.appmod.create_app()
         update_single = app.callbacks["_update_single"]
 
@@ -295,8 +295,9 @@ class TestAppUtilities(unittest.TestCase):
             "rt_vals": [],
             "rt_roll_x": [],
             "rt_roll_y": [],
-            "gap_times_correct": [0.2, 0.25],
-            "gap_times_incorrect": [0.4],
+            "response_times": [0.2, 0.25, 0.4],
+            "response_times_correct": [0.2, 0.25],
+            "response_times_incorrect": [0.4],
             "iti_times": [0.8, 1.1, 1.0],
             "trial_count_x": [2.5, 7.5],
             "trial_count_y": [20.0, 18.0],
@@ -311,8 +312,8 @@ class TestAppUtilities(unittest.TestCase):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
 
         self.assertEqual(len(figures), 13)
-        self.assertEqual(figures[10].layout["title"]["text"], "Gap time by outcome")
-        self.assertEqual(len(figures[10].traces), 2)
+        self.assertEqual(figures[10].layout["title"]["text"], "Response Time")
+        self.assertEqual(len(figures[10].traces), 3)
         self.assertIn("yaxis_range", figures[4].layout)  # init-line
         self.assertIn("yaxis_range", figures[6].layout)  # wait-delta-line
         self.assertIn("yaxis_range", figures[8].layout)  # wait-floor-line

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -220,12 +220,30 @@ def _make_session_metrics() -> dict:
         wait_trial_nums=trial_nums,
         wait_delta_x=roll_x,
         wait_delta_y=rng.uniform(0.0, 1.0, nroll).tolist(),
+        wait_delta_left_times=rng.uniform(0.0, 1.0, n // 2).tolist(),
+        wait_delta_right_times=rng.uniform(0.0, 1.0, n // 2).tolist(),
+        wait_trial_nums_left=trial_nums[::2],
+        wait_trial_nums_right=trial_nums[1::2],
+        wait_delta_left_x=roll_x,
+        wait_delta_left_y=rng.uniform(0.0, 1.0, nroll).tolist(),
+        wait_delta_right_x=roll_x,
+        wait_delta_right_y=rng.uniform(0.0, 1.0, nroll).tolist(),
         wait_roll_x=roll_x,
         wait_roll_y=rng.uniform(0.5, 2.0, nroll).tolist(),
+        wait_times_left=rng.uniform(0.5, 3.0, n // 2).tolist(),
+        wait_times_right=rng.uniform(0.5, 3.0, n // 2).tolist(),
+        wait_left_x=roll_x,
+        wait_left_y=rng.uniform(0.5, 2.0, nroll).tolist(),
+        wait_right_x=roll_x,
+        wait_right_y=rng.uniform(0.5, 2.0, nroll).tolist(),
         response_times=rng.uniform(0.05, 0.8, n).tolist(),
         response_times_correct=rng.uniform(0.05, 0.5, n // 2).tolist(),
         response_times_incorrect=rng.uniform(0.2, 0.9, n // 2).tolist(),
         iti_times=rng.uniform(0.5, 3.0, n).tolist(),
+        iti_times_after_correct=rng.uniform(0.5, 3.0, n // 4).tolist(),
+        iti_times_after_incorrect=rng.uniform(0.5, 3.0, n // 4).tolist(),
+        iti_times_after_ew=rng.uniform(0.5, 3.0, n // 4).tolist(),
+        iti_times_after_no_choice=rng.uniform(0.5, 3.0, n // 4).tolist(),
         trial_count_x=[2.5, 7.5, 12.5, 17.5],
         trial_count_y=[25.0, 20.0, 18.0, 12.0],
         slide_x=roll_x,
@@ -597,15 +615,33 @@ class TestSessionMetricsWithRealLibs(unittest.TestCase):
             "wait_times",
             "wait_min_times",
             "wait_delta_times",
+            "wait_delta_left_times",
+            "wait_delta_right_times",
             "wait_trial_nums",
+            "wait_trial_nums_left",
+            "wait_trial_nums_right",
             "wait_delta_x",
             "wait_delta_y",
+            "wait_delta_left_x",
+            "wait_delta_left_y",
+            "wait_delta_right_x",
+            "wait_delta_right_y",
             "wait_roll_x",
             "wait_roll_y",
+            "wait_times_left",
+            "wait_times_right",
+            "wait_left_x",
+            "wait_left_y",
+            "wait_right_x",
+            "wait_right_y",
             "slide_x",
             "slide_y",
             "ew_roll_x",
             "ew_roll_y",
+            "iti_times_after_correct",
+            "iti_times_after_incorrect",
+            "iti_times_after_ew",
+            "iti_times_after_no_choice",
         }
         self.assertEqual(set(result.keys()), expected_keys)
 
@@ -725,20 +761,24 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # P(right) and chronometric charts have one trace each
         self.assertEqual(len(figures[1].data), 1)
         self.assertEqual(len(figures[2].data), 1)
-        # Wait-floor plot (index 8): raw markers + rolling line = 2 traces
-        self.assertEqual(len(figures[8].data), 2)
+        # Wait-floor plot includes aggregate + split traces with aggregate visible by default.
+        self.assertGreaterEqual(len(figures[8].data), 2)
         # Timing scatter panels apply robust default y-axis clipping.
         self.assertIsNotNone(figures[4].layout.yaxis.range)
         self.assertIsNotNone(figures[6].layout.yaxis.range)
         self.assertIsNotNone(figures[8].layout.yaxis.range)
-        # Wait-floor-hist (index 9): single Histogram trace
-        self.assertEqual(len(figures[9].data), 1)
+        # Wait-floor-hist includes aggregate + split traces.
+        self.assertGreaterEqual(len(figures[9].data), 1)
         self.assertIsInstance(figures[9].data[0], go.Histogram)
         # Response-time plot (index 10): combined histogram + split hidden traces
         self.assertGreaterEqual(len(figures[10].data), 3)
         self.assertIsInstance(figures[10].data[0], go.Histogram)
-        # ITI dist (index 11) is histogram in single-subject mode
-        self.assertEqual(len(figures[11].data), 1)
+        self.assertEqual(figures[10].layout.updatemenus[0].buttons[0].label, "Outcome")
+        self.assertEqual(figures[6].layout.updatemenus[0].buttons[0].label, "Choice")
+        self.assertEqual(figures[8].layout.updatemenus[0].buttons[0].label, "Choice")
+        self.assertEqual(figures[11].layout.updatemenus[0].buttons[0].label, "Outcome")
+        # ITI dist (index 11) includes aggregate + split traces.
+        self.assertGreaterEqual(len(figures[11].data), 1)
         self.assertIsInstance(figures[11].data[0], go.Histogram)
         # Trial-count-time (index 12) is bar in single-subject mode
         self.assertEqual(len(figures[12].data), 1)
@@ -767,8 +807,8 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(figures[0].data[0].orientation, "h")
         # Initiation dist uses Box in multi mode
         self.assertIsInstance(figures[5].data[0], go.Box)
-        # Wait floor (index 8): raw + rolling traces per subject (2 subjects = 4)
-        self.assertEqual(len(figures[8].data), 4)
+        # Wait floor includes aggregate + split traces in multi-subject mode.
+        self.assertGreaterEqual(len(figures[8].data), 4)
         # Wait-floor dist (index 9) uses Box in multi mode
         self.assertIsInstance(figures[9].data[0], go.Box)
         # Response-time plot (index 10) uses per-subject box plots in multi mode

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -222,6 +222,12 @@ def _make_session_metrics() -> dict:
         wait_delta_y=rng.uniform(0.0, 1.0, nroll).tolist(),
         wait_roll_x=roll_x,
         wait_roll_y=rng.uniform(0.5, 2.0, nroll).tolist(),
+        gap_times=rng.uniform(0.05, 0.8, n).tolist(),
+        gap_times_correct=rng.uniform(0.05, 0.5, n // 2).tolist(),
+        gap_times_incorrect=rng.uniform(0.2, 0.9, n // 2).tolist(),
+        iti_times=rng.uniform(0.5, 3.0, n).tolist(),
+        trial_count_x=[2.5, 7.5, 12.5, 17.5],
+        trial_count_y=[25.0, 20.0, 18.0, 12.0],
         slide_x=roll_x,
         slide_y=rng.uniform(0.5, 0.9, nroll).tolist(),
         ew_roll_x=roll_x,
@@ -338,6 +344,22 @@ class TestPlotlyApiSurface(unittest.TestCase):
                 marker_color="#1f77b4",
                 showlegend=False,
                 opacity=0.8,
+            )
+        )
+
+    def test_violin_trace_accepts_app_kwargs(self):
+        go.Figure().add_trace(
+            go.Violin(
+                x=["subject-a", "subject-a", "subject-a"],
+                y=[0.2, 0.25, 0.3],
+                name="Correct",
+                legendgroup="gap-correct",
+                showlegend=True,
+                line_color="mediumseagreen",
+                side="negative",
+                meanline_visible=True,
+                points=False,
+                scalegroup="subject-a",
             )
         )
 
@@ -562,6 +584,12 @@ class TestSessionMetricsWithRealLibs(unittest.TestCase):
             "rt_vals",
             "rt_roll_x",
             "rt_roll_y",
+            "gap_times",
+            "gap_times_correct",
+            "gap_times_incorrect",
+            "iti_times",
+            "trial_count_x",
+            "trial_count_y",
             "init_times",
             "init_trial_nums",
             "init_roll_x",
@@ -677,7 +705,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.addCleanup(lambda: sys.modules.pop("chipmunk_dashboard.app", None))
         self.appmod = _import_app_fake_dash_real_plotly()
 
-    def test_update_single_single_subject_returns_eleven_figures(self):
+    def test_update_single_single_subject_returns_thirteen_figures(self):
         app = self.appmod.create_app()
         update_single = app.callbacks["_update_single"]
         sm = _make_session_metrics()
@@ -689,7 +717,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
 
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Single-subject outcome chart: 4 vertical bar traces (one per outcome type)
@@ -699,9 +727,22 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(len(figures[2].data), 1)
         # Wait-floor plot (index 8): raw markers + rolling line = 2 traces
         self.assertEqual(len(figures[8].data), 2)
+        # Timing scatter panels apply robust default y-axis clipping.
+        self.assertIsNotNone(figures[4].layout.yaxis.range)
+        self.assertIsNotNone(figures[6].layout.yaxis.range)
+        self.assertIsNotNone(figures[8].layout.yaxis.range)
         # Wait-floor-hist (index 9): single Histogram trace
         self.assertEqual(len(figures[9].data), 1)
         self.assertIsInstance(figures[9].data[0], go.Histogram)
+        # Gap-time plot (index 10): violin traces by outcome
+        self.assertGreaterEqual(len(figures[10].data), 2)
+        self.assertIsInstance(figures[10].data[0], go.Violin)
+        # ITI dist (index 11) is histogram in single-subject mode
+        self.assertEqual(len(figures[11].data), 1)
+        self.assertIsInstance(figures[11].data[0], go.Histogram)
+        # Trial-count-time (index 12) is bar in single-subject mode
+        self.assertEqual(len(figures[12].data), 1)
+        self.assertIsInstance(figures[12].data[0], go.Bar)
 
     def test_update_single_multi_subject_uses_box_and_horizontal_bars(self):
         app = self.appmod.create_app()
@@ -717,7 +758,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Multi-col outcome chart: 4 horizontal bar traces
@@ -730,8 +771,13 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(len(figures[8].data), 4)
         # Wait-floor dist (index 9) uses Box in multi mode
         self.assertIsInstance(figures[9].data[0], go.Box)
-        # Reaction time dist (index 11) uses Box in multi mode
+        # Gap-time plot (index 10) uses split violin traces
+        self.assertGreaterEqual(len(figures[10].data), 2)
+        self.assertIsInstance(figures[10].data[0], go.Violin)
+        # ITI dist (index 11) uses Box in multi mode
         self.assertIsInstance(figures[11].data[0], go.Box)
+        # Trial-count-time (index 12) uses scatter in multi mode
+        self.assertIsInstance(figures[12].data[0], go.Scatter)
 
     def test_update_multi_with_data_returns_eight_figures(self):
         app = self.appmod.create_app()
@@ -775,7 +821,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], ["subject-b"], "20260101_010101", 0, "2026-01-01"
             )
 
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
 
     def test_update_multi_recent_and_older_subjects_are_merged(self):
         """Subjects from both checklists are combined and processed together."""
@@ -795,7 +841,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # ses = "" which is falsy → the loop body is skipped via continue.
         with mock.patch.object(self.appmod, "get_sessions", return_value=[""]):
             figures = update_single(["subject-a"], [], None, 0, None)
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
@@ -810,7 +856,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
             mock.patch.object(self.appmod, "session_metrics", return_value=None),
         ):
             figures = update_single(["subject-a"], [], "20260101_010101", 0, None)
-        self.assertEqual(len(figures), 12)
+        self.assertEqual(len(figures), 13)
 
     def test_update_multi_skips_subject_when_multisession_metrics_none(self):
         """Line 1128: `if not ms: continue` — multisession_metrics returns None."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -222,9 +222,9 @@ def _make_session_metrics() -> dict:
         wait_delta_y=rng.uniform(0.0, 1.0, nroll).tolist(),
         wait_roll_x=roll_x,
         wait_roll_y=rng.uniform(0.5, 2.0, nroll).tolist(),
-        gap_times=rng.uniform(0.05, 0.8, n).tolist(),
-        gap_times_correct=rng.uniform(0.05, 0.5, n // 2).tolist(),
-        gap_times_incorrect=rng.uniform(0.2, 0.9, n // 2).tolist(),
+        response_times=rng.uniform(0.05, 0.8, n).tolist(),
+        response_times_correct=rng.uniform(0.05, 0.5, n // 2).tolist(),
+        response_times_incorrect=rng.uniform(0.2, 0.9, n // 2).tolist(),
         iti_times=rng.uniform(0.5, 3.0, n).tolist(),
         trial_count_x=[2.5, 7.5, 12.5, 17.5],
         trial_count_y=[25.0, 20.0, 18.0, 12.0],
@@ -584,9 +584,9 @@ class TestSessionMetricsWithRealLibs(unittest.TestCase):
             "rt_vals",
             "rt_roll_x",
             "rt_roll_y",
-            "gap_times",
-            "gap_times_correct",
-            "gap_times_incorrect",
+            "response_times",
+            "response_times_correct",
+            "response_times_incorrect",
             "iti_times",
             "trial_count_x",
             "trial_count_y",
@@ -734,9 +734,9 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # Wait-floor-hist (index 9): single Histogram trace
         self.assertEqual(len(figures[9].data), 1)
         self.assertIsInstance(figures[9].data[0], go.Histogram)
-        # Gap-time plot (index 10): violin traces by outcome
-        self.assertGreaterEqual(len(figures[10].data), 2)
-        self.assertIsInstance(figures[10].data[0], go.Violin)
+        # Response-time plot (index 10): combined histogram + split hidden traces
+        self.assertGreaterEqual(len(figures[10].data), 3)
+        self.assertIsInstance(figures[10].data[0], go.Histogram)
         # ITI dist (index 11) is histogram in single-subject mode
         self.assertEqual(len(figures[11].data), 1)
         self.assertIsInstance(figures[11].data[0], go.Histogram)
@@ -771,9 +771,8 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(len(figures[8].data), 4)
         # Wait-floor dist (index 9) uses Box in multi mode
         self.assertIsInstance(figures[9].data[0], go.Box)
-        # Gap-time plot (index 10) uses split violin traces
-        self.assertGreaterEqual(len(figures[10].data), 2)
-        self.assertIsInstance(figures[10].data[0], go.Violin)
+        # Response-time plot (index 10) uses per-subject box plots in multi mode
+        self.assertIsInstance(figures[10].data[0], go.Box)
         # ITI dist (index 11) uses Box in multi mode
         self.assertIsInstance(figures[11].data[0], go.Box)
         # Trial-count-time (index 12) uses scatter in multi mode

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -237,8 +237,8 @@ def _make_session_metrics() -> dict:
         wait_right_x=roll_x,
         wait_right_y=rng.uniform(0.5, 2.0, nroll).tolist(),
         response_times=rng.uniform(0.05, 0.8, n).tolist(),
-        response_times_correct=rng.uniform(0.05, 0.5, n // 2).tolist(),
-        response_times_incorrect=rng.uniform(0.2, 0.9, n // 2).tolist(),
+        response_times_left=rng.uniform(0.05, 0.5, n // 2).tolist(),
+        response_times_right=rng.uniform(0.2, 0.9, n // 2).tolist(),
         iti_times=rng.uniform(0.5, 3.0, n).tolist(),
         iti_times_after_correct=rng.uniform(0.5, 3.0, n // 4).tolist(),
         iti_times_after_incorrect=rng.uniform(0.5, 3.0, n // 4).tolist(),
@@ -603,8 +603,8 @@ class TestSessionMetricsWithRealLibs(unittest.TestCase):
             "rt_roll_x",
             "rt_roll_y",
             "response_times",
-            "response_times_correct",
-            "response_times_incorrect",
+            "response_times_left",
+            "response_times_right",
             "iti_times",
             "trial_count_x",
             "trial_count_y",
@@ -773,7 +773,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # Response-time plot (index 10): combined histogram + split hidden traces
         self.assertGreaterEqual(len(figures[10].data), 3)
         self.assertIsInstance(figures[10].data[0], go.Histogram)
-        self.assertEqual(figures[10].layout.updatemenus[0].buttons[0].label, "Outcome")
+        self.assertEqual(figures[10].layout.updatemenus[0].buttons[0].label, "Choice")
         self.assertEqual(figures[6].layout.updatemenus[0].buttons[0].label, "Choice")
         self.assertEqual(figures[8].layout.updatemenus[0].buttons[0].label, "Choice")
         self.assertEqual(figures[11].layout.updatemenus[0].buttons[0].label, "Outcome")


### PR DESCRIPTION
## Summary\n- rename wait-delta titles to Post-Go Center Dwell\n- remove legacy reaction-time plots\n- redesign response-time panel with split toggle\n- add independent Choice/Outcome split toggles for timing/ITI views\n- switch response-time split to Left/Right choice\n\n## Validation\n- ruff check\n- ruff format --check\n- pytest with coverage