### PR TITLE
Show session date in multisession hover

### DIFF
--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -2390,13 +2390,15 @@ def create_app() -> Dash:
             )
             if not ms:
                 continue
-            ht = "%{y:.2f}<extra>" + subj + "</extra>"
+            session_dates = ms.get("session_dates", [])
+            ht = "%{y:.2f}<br>session date: %{customdata}<extra>" + subj + "</extra>"
             mk = dict(color=c, size=7)
             ln = dict(color=c, width=2)
 
             fig_perf.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["perf_easy"],
                     mode="lines+markers",
                     name=subj,
@@ -2410,6 +2412,7 @@ def create_app() -> Dash:
             fig_ew.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["ew_rate"],
                     mode="lines+markers",
                     name=subj,
@@ -2423,6 +2426,7 @@ def create_app() -> Dash:
             fig_sb.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["side_bias"],
                     mode="lines+markers",
                     name=subj,
@@ -2436,6 +2440,7 @@ def create_app() -> Dash:
             fig_it.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_init"],
                     mode="lines+markers",
                     name=subj,
@@ -2443,12 +2448,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_mrt.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_rt"],
                     mode="lines+markers",
                     name=subj,
@@ -2456,12 +2464,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_mwt.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_wait"],
                     mode="lines+markers",
                     name=subj,
@@ -2469,12 +2480,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_tc.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["n_with_choice"],
                     mode="lines+markers",
                     name=subj,
@@ -2482,12 +2496,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     line=dict(color=c),
                     marker=mk,
-                    hovertemplate="%{y}<extra>" + subj + "</extra>",
+                    hovertemplate="%{y}<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_wa.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["water"],
                     mode="lines+markers",
                     name=subj,
@@ -2495,7 +2512,9 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.2f} mL<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.2f} mL<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
 

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1116,6 +1116,12 @@ def multisession_metrics(
     initiation_values = d["initiation_times"].tolist()
     reaction_values = d["reaction_times"].tolist()
     session_names = d["session_name"].tolist()
+    session_dates = [
+        f"{name[:4]}-{name[4:6]}-{name[6:8]}"
+        if isinstance(name, str) and len(name) >= 8
+        else str(name)
+        for name in session_names
+    ]
 
     ew_rate: list[float] = []
     side_bias: list[float] = []
@@ -1184,6 +1190,7 @@ def multisession_metrics(
             out[k] = np.asarray(v).tolist()
 
     out["x"] = [float(x) for x in x_axis]
+    out["session_dates"] = session_dates
     _perf_log(
         "multisession_metrics",
         start,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -312,6 +312,7 @@ def _make_multisession_metrics() -> dict:
     rng = np.random.default_rng(42)
     return dict(
         x=[float(i - 9) for i in range(n)],
+        session_dates=[f"2026-01-{i + 1:02d}" for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -868,6 +869,7 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         self.assertIsNotNone(result)
         expected_keys = {
             "x",
+            "session_dates",
             "perf_easy",
             "ew_rate",
             "n_with_choice",
@@ -1048,6 +1050,17 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # Performance figure should have one Scatter trace
         self.assertEqual(len(figures[0].data), 1)
         self.assertIsInstance(figures[0].data[0], go.Scatter)
+
+    def test_update_multi_hover_shows_session_date(self):
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = _make_multisession_metrics()
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        perf_trace = figures[0].data[0]
+        self.assertEqual(list(perf_trace.customdata), ms["session_dates"])
+        self.assertIn("session date: %{customdata}", perf_trace.hovertemplate)
 
     def test_update_multi_smooth_enabled_still_returns_eight_figures(self):
         app = self.appmod.create_app()


### PR DESCRIPTION
## Summary
- show the session date when hovering points in the multi-session plots
- thread formatted `session_dates` through `multisession_metrics()` so the callback can attach them as Plotly `customdata`
- update integration coverage to verify the hover payload and template

Closes #45

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`