### PR TITLE
Pin setuptools to 79.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "setuptools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "pandas",
     "numpy",
     "labdata>=0.0.22",
-    "setuptools<81",
+    # Newer setuptools releases break the real labdata/datajoint import path.
+    "setuptools==79.0.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly", specifier = "<6" },
-    { name = "setuptools", specifier = "<81" },
+    { name = "setuptools", specifier = "==79.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -2470,11 +2470,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.0.0"
+version = "79.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/80/97e25f0f1e4067677806084b7382a6ff9979f3d15119375c475c288db9d7/setuptools-80.0.0.tar.gz", hash = "sha256:c40a5b3729d58dd749c0f08f1a07d134fb8a0a3d7f87dc33e7c5e1f762138650", size = 1354221, upload-time = "2025-04-27T17:21:10.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/63/5517029d6696ddf2bd378d46f63f479be001c31b462303170a1da57650cb/setuptools-80.0.0-py3-none-any.whl", hash = "sha256:a38f898dcd6e5380f4da4381a87ec90bd0a7eec23d204a5552e80ee3cab6bd27", size = 1240907, upload-time = "2025-04-27T17:21:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- pin `setuptools` to `79.0.1` to avoid the known `labdata`/`datajoint` compatibility break
- add a Dependabot ignore rule for `setuptools` so this does not keep resurfacing
- refresh `uv.lock` to keep the lockfile aligned with the exact pin

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`