### PR TITLE
Allow Plotly 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "dash",
-    "plotly<6",
+    "plotly<7",
     "pandas",
     "numpy",
     "labdata>=0.0.22",

--- a/uv.lock
+++ b/uv.lock
@@ -339,7 +339,7 @@ requires-dist = [
     { name = "labdata", specifier = ">=0.0.22" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "plotly", specifier = "<6" },
+    { name = "plotly", specifier = "<7" },
     { name = "setuptools", specifier = "==79.0.1" },
 ]
 


### PR DESCRIPTION
## Summary
- widen the Plotly constraint from `<6` to `<7`
- refresh the lock metadata to match the new constraint
- keep the diff limited to the Plotly version allowance only

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`
- `RUN_PLAYWRIGHT=1 uv run pytest tests/test_playwright_ui.py`