### PR TITLE
[codex] Use session datetimes in multi-session plots

### DIFF
--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -2377,9 +2377,12 @@ def create_app() -> Dash:
             grp = subj
 
             # Anchor Handling:
-            # - We use 'session_date' (YYYY-MM-DD string) as the anchor for EVERY subject.
-            # - This aligns "0" to that date for all subjects.
-            # - If date is None (startup), session_date usually defaults to latest, but we handle None.
+            # - We use 'session_date' (YYYY-MM-DD string) as the upper-date filter
+            #   for EVERY subject.
+            # - Each series still plots the true session datetime on the x-axis so
+            #   multiple sessions from one day remain visually distinct.
+            # - If date is None (startup), session_date usually defaults to latest,
+            #   but we handle None.
 
             ms = multisession_metrics(
                 subj,
@@ -2520,11 +2523,11 @@ def create_app() -> Dash:
 
         _ref_line = dict(line_dash="dash", line_color="grey", line_width=1)
 
-        _ms = dict(dtick=5, showgrid=False, zeroline=False)
+        _ms = dict(type="date", showgrid=False, zeroline=False)
         _layout(
             fig_perf,
             title="Performance (easy)",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="performance",
             yaxis_range=[0.3, 1],
             xaxis=_ms,
@@ -2534,7 +2537,7 @@ def create_app() -> Dash:
         _layout(
             fig_ew,
             title="E.W. Rate",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="e.w. rate",
             yaxis_range=[0, 1],
             xaxis=_ms,
@@ -2552,7 +2555,7 @@ def create_app() -> Dash:
         _layout(
             fig_sb,
             title="Bias Index",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="bias (R - L)",
             yaxis_range=[-0.6, 0.6],
             xaxis=_ms,
@@ -2562,35 +2565,35 @@ def create_app() -> Dash:
         _layout(
             fig_it,
             title="Median Initiation Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_mrt,
             title="Median Response Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_mwt,
             title="Median Wait Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_tc,
             title="Trials with Choice",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="trials",
             xaxis=_ms,
         )
         _layout(
             fig_wa,
             title="Water Earned",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="volume (mL)",
             xaxis=_ms,
         )

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1073,10 +1073,18 @@ def multisession_metrics(
 
     df = df.sort_values("session_name")
 
-    # Parse session dates for filtering
-    df["date"] = pd.to_datetime(
-        df["session_name"].str.slice(0, 8), format="%Y%m%d", errors="coerce"
+    # Parse full session datetimes so same-day sessions keep distinct x positions.
+    df["session_dt"] = pd.to_datetime(
+        df["session_name"], format="%Y%m%d_%H%M%S", errors="coerce"
     )
+    missing_dt = df["session_dt"].isna()
+    if missing_dt.any():
+        df.loc[missing_dt, "session_dt"] = pd.to_datetime(
+            df.loc[missing_dt, "session_name"].astype(str).str.slice(0, 8),
+            format="%Y%m%d",
+            errors="coerce",
+        )
+    df["date"] = df["session_dt"].dt.normalize()
 
     # Filter by date if provided
     if start_date:
@@ -1084,9 +1092,9 @@ def multisession_metrics(
         # Keep sessions <= start_date
         df = df[df["date"] <= anchor_dt]
     else:
-        # If no date provided, use the latest session date of this subject as anchor
+        # If no date provided, use the latest session timestamp of this subject.
         if not df.empty:
-            anchor_dt = df["date"].iloc[-1]
+            anchor_dt = df["session_dt"].iloc[-1]
         else:  # pragma: no cover — df can't be empty here (already checked above)
             _perf_log("multisession_metrics", start, subject=subject, sessions=0)
             return None
@@ -1099,28 +1107,34 @@ def multisession_metrics(
     wait_medians = get_wait_medians_for_sessions(subject, d_session_names)
     water_by_session = get_subject_water(subject)
 
-    # Calculate X-axis (Days relative to anchor_dt)
-    # This aligns 0 to the shared anchor date (or this subject's latest date if none shared)
     try:
-        anchor_ts = pd.Timestamp(anchor_dt)
         x_axis = [
-            float((pd.Timestamp(v) - anchor_ts).days) if pd.notna(v) else float("nan")
-            for v in d["date"].tolist()
+            pd.Timestamp(v).isoformat(sep=" ")
+            if pd.notna(v)
+            else pd.Timestamp(d["date"].iloc[i]).isoformat(sep=" ")
+            for i, v in enumerate(d["session_dt"].tolist())
         ]
-    except (
-        Exception
-    ):  # pragma: no cover — defensive fallback for unexpected timestamp types
-        x_axis = [float(i) for i in range(-len(d) + 1, 1)]
+    except Exception:  # pragma: no cover — defensive fallback for unexpected types
+        x_axis = [
+            pd.Timestamp(v).isoformat(sep=" ") if pd.notna(v) else str(name)
+            for v, name in zip(
+                d["date"].tolist(), d["session_name"].tolist(), strict=False
+            )
+        ]
 
     response_values = d["response_values"].tolist()
     initiation_values = d["initiation_times"].tolist()
     reaction_values = d["reaction_times"].tolist()
     session_names = d["session_name"].tolist()
     session_dates = [
-        f"{name[:4]}-{name[4:6]}-{name[6:8]}"
-        if isinstance(name, str) and len(name) >= 8
-        else str(name)
-        for name in session_names
+        pd.Timestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+        if pd.notna(ts)
+        else (
+            f"{name[:4]}-{name[4:6]}-{name[6:8]}"
+            if isinstance(name, str) and len(name) >= 8
+            else str(name)
+        )
+        for ts, name in zip(d["session_dt"].tolist(), session_names, strict=False)
     ]
 
     ew_rate: list[float] = []
@@ -1172,7 +1186,7 @@ def multisession_metrics(
         water=np.array(water),
     )
 
-    out: dict[str, list[float]] = {}
+    out: dict[str, list[Any]] = {}
     if smooth and smooth_window > 1:
         # Simple moving average, handling NaNs
         # We can use pandas rolling on a temporary series for each metric
@@ -1189,7 +1203,7 @@ def multisession_metrics(
         for k, v in res.items():
             out[k] = np.asarray(v).tolist()
 
-    out["x"] = [float(x) for x in x_axis]
+    out["x"] = x_axis
     out["session_dates"] = session_dates
     _perf_log(
         "multisession_metrics",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -311,8 +311,8 @@ def _make_multisession_metrics() -> dict:
     n = 10
     rng = np.random.default_rng(42)
     return dict(
-        x=[float(i - 9) for i in range(n)],
-        session_dates=[f"2026-01-{i + 1:02d}" for i in range(n)],
+        x=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
+        session_dates=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -1061,6 +1061,9 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         perf_trace = figures[0].data[0]
         self.assertEqual(list(perf_trace.customdata), ms["session_dates"])
         self.assertIn("session date: %{customdata}", perf_trace.hovertemplate)
+        self.assertEqual(list(perf_trace.x), ms["x"])
+        self.assertEqual(figures[0].layout.xaxis.type, "date")
+        self.assertEqual(figures[0].layout.xaxis.title.text, "session datetime")
 
     def test_update_multi_smooth_enabled_still_returns_eight_figures(self):
         app = self.appmod.create_app()
@@ -1260,6 +1263,48 @@ class TestDataNonEmptyPaths(unittest.TestCase):
         self.assertIsNotNone(result)
         # Only Jan 1-5 pass the <= filter; sessions_back=10 keeps all 5.
         self.assertEqual(len(result["x"]), 5)
+
+    def test_multisession_metrics_keeps_same_day_sessions_distinct_on_x_axis(self):
+        df = pd.DataFrame(
+            {
+                "session_name": [
+                    "20260105_090000",
+                    "20260105_150000",
+                    "20260106_120000",
+                ],
+                "performance_easy": [0.6, 0.7, 0.8],
+                "n_with_choice": [60, 65, 70],
+                "response_values": [[-1, 1]] * 3,
+                "initiation_times": [[0.5, 0.6]] * 3,
+                "reaction_times": [[0.2, 0.3]] * 3,
+            }
+        )
+        with (
+            mock.patch.object(self.data, "get_subject_data", return_value=df),
+            mock.patch.object(
+                self.data, "get_wait_medians_for_sessions", return_value={}
+            ),
+            mock.patch.object(self.data, "get_subject_water", return_value={}),
+        ):
+            result = self.data.multisession_metrics("subject-a", sessions_back=10)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["x"],
+            [
+                "2026-01-05 09:00:00",
+                "2026-01-05 15:00:00",
+                "2026-01-06 12:00:00",
+            ],
+        )
+        self.assertEqual(
+            result["session_dates"],
+            [
+                "2026-01-05 09:00:00",
+                "2026-01-05 15:00:00",
+                "2026-01-06 12:00:00",
+            ],
+        )
 
     # -- multisession_metrics: side_bias no-choice path (line 730) ------------
 


### PR DESCRIPTION
## Summary
- use full session datetimes for multi-session plot x-values instead of day offsets
- render multi-session charts on a date axis so same-day sessions stay visually distinct
- add regression coverage for same-day sessions and datetime axis wiring

## Why
The multi-session plots were collapsing all sessions from the same calendar day onto the same x-position because the x-axis only tracked whole-day offsets. That made multiple sessions in one day look equally spaced from neighboring days instead of close together in time.

## Validation
- `uv run ruff check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`
- `RUN_PLAYWRIGHT=1 uv run pytest tests/test_playwright_ui.py`

Closes #54
