### PR TITLE
[codex] Block future dates in session picker

### DIFF
--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -710,13 +710,13 @@ def create_app() -> Dash:
         Side Effects:
             Triggers multi-session cache prewarming anchored to the latest date.
         """
+        today = _date.today().isoformat()
         if ctx.triggered_id == "today-button":
-            today = _date.today().isoformat()
-            return today, None, None, today
+            return today, None, today, today
 
         subjects = (subjects_recent or []) + (subjects_older or [])
         if not subjects:
-            return None, None, None, None
+            return None, None, today, today
 
         all_dates = [
             f"{s[:4]}-{s[4:6]}-{s[6:8]}"
@@ -726,12 +726,12 @@ def create_app() -> Dash:
         ]
 
         if not all_dates:
-            return None, None, None, None
+            return None, None, today, today
 
         min_d = min(all_dates)
-        max_d = max(all_dates)
+        max_d = min(max(all_dates), today)
         prewarm_multisession_cache(subjects, sessions_back=30, start_date=max_d)
-        return max_d, min_d, max_d, max_d  # Default to latest
+        return max_d, min_d, today, max_d
 
     @app.callback(
         Output("session-time", "options"),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -180,39 +180,87 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
 
-        self.assertEqual(update_date_options([], [], 0, 0), (None, None, None, None))
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        with mock.patch.object(self.appmod, "_date", _FakeDate):
+            self.assertEqual(
+                update_date_options([], [], 0, 0),
+                (None, None, "2026-01-10", "2026-01-10"),
+            )
+
+            with (
+                mock.patch.object(
+                    self.appmod,
+                    "get_sessions",
+                    return_value=["20260101_010101", "20260103_010101", "bad"],
+                ),
+                mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
+            ):
+                result = update_date_options([], ["subject-a"], 0, 0)
+
+            self.assertEqual(
+                result, ("2026-01-03", "2026-01-01", "2026-01-10", "2026-01-03")
+            )
+            prewarm.assert_called_once_with(
+                ["subject-a"], sessions_back=30, start_date="2026-01-03"
+            )
+
+    def test_update_date_options_today_button_returns_todays_date(self) -> None:
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        self.appmod.ctx.triggered_id = "today-button"
+        try:
+            with mock.patch.object(self.appmod, "_date", _FakeDate):
+                date_val, min_d, max_d, month = update_date_options([], [], 0, 1)
+        finally:
+            self.appmod.ctx.triggered_id = None
+
+        self.assertEqual(date_val, "2026-01-10")
+        self.assertIsNone(min_d)
+        self.assertEqual(max_d, "2026-01-10")
+        self.assertEqual(month, "2026-01-10")
+
+    def test_update_date_options_caps_future_sessions_at_today(self) -> None:
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
 
         with (
+            mock.patch.object(self.appmod, "_date", _FakeDate),
             mock.patch.object(
                 self.appmod,
                 "get_sessions",
-                return_value=["20260101_010101", "20260103_010101", "bad"],
+                return_value=["20260105_010101", "20260114_120000"],
             ),
             mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
         ):
             result = update_date_options([], ["subject-a"], 0, 0)
 
         self.assertEqual(
-            result, ("2026-01-03", "2026-01-01", "2026-01-03", "2026-01-03")
+            result, ("2026-01-10", "2026-01-05", "2026-01-10", "2026-01-10")
         )
         prewarm.assert_called_once_with(
-            ["subject-a"], sessions_back=30, start_date="2026-01-03"
+            ["subject-a"], sessions_back=30, start_date="2026-01-10"
         )
-
-    def test_update_date_options_today_button_returns_todays_date(self) -> None:
-        app = self.appmod.create_app()
-        update_date_options = app.callbacks["_update_date_options"]
-        self.appmod.ctx.triggered_id = "today-button"
-        try:
-            date_val, min_d, max_d, month = update_date_options([], [], 0, 1)
-        finally:
-            self.appmod.ctx.triggered_id = None
-        from datetime import date
-
-        self.assertEqual(date_val, date.today().isoformat())
-        self.assertIsNone(min_d)
-        self.assertIsNone(max_d)
-        self.assertEqual(month, date.today().isoformat())
 
     def test_update_time_options_filters_and_defaults_to_latest(self) -> None:
         app = self.appmod.create_app()
@@ -462,14 +510,30 @@ class TestAppUtilities(unittest.TestCase):
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
             result = update_date_options([], ["subject-a"], 0, 0)
-        self.assertEqual(result, (None, None, None, None))
+        self.assertEqual(
+            result,
+            (
+                None,
+                None,
+                self.appmod._date.today().isoformat(),
+                self.appmod._date.today().isoformat(),
+            ),
+        )
 
     def test_update_date_options_returns_none_when_all_sessions_too_short(self) -> None:
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=["short"]):
             result = update_date_options([], ["subject-a"], 0, 0)
-        self.assertEqual(result, (None, None, None, None))
+        self.assertEqual(
+            result,
+            (
+                None,
+                None,
+                self.appmod._date.today().isoformat(),
+                self.appmod._date.today().isoformat(),
+            ),
+        )
 
     def test_update_time_options_returns_empty_when_no_sessions_on_date(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1105,6 +1105,35 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
 
         self.assertEqual(len(figures), 8)
 
+    def test_update_date_options_caps_future_dates_at_today(self):
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        with (
+            mock.patch.object(self.appmod, "_date", _FakeDate),
+            mock.patch.object(
+                self.appmod,
+                "get_sessions",
+                return_value=["20260105_010101", "20260114_120000"],
+            ),
+            mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
+        ):
+            result = update_date_options([], ["subject-a"], 0, 0)
+
+        self.assertEqual(
+            result, ("2026-01-10", "2026-01-05", "2026-01-10", "2026-01-10")
+        )
+        prewarm.assert_called_once_with(
+            ["subject-a"], sessions_back=30, start_date="2026-01-10"
+        )
+
     def test_update_single_skips_subjects_with_falsy_session_name(self):
         """Line 590: `if not ses: continue` — session name resolves to empty string."""
         app = self.appmod.create_app()


### PR DESCRIPTION
## Summary
- cap the session date picker at today even when subjects have future-dated sessions
- preserve subject-driven minimum dates while defaulting the selected date to the latest non-future date
- add unit and integration coverage for the capped date-picker behavior

## Why
Issue #52 requests that future dates not be selectable in the calendar. The picker previously exposed the raw latest session date, which could make future dates selectable and set the default date beyond today.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`

Closes #52
