### PR TITLE
[codex] Add training time multi-session plot

### DIFF
--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -2639,7 +2639,7 @@ def create_app() -> Dash:
             yaxis_title="time of day",
             xaxis=_ms,
             yaxis=dict(
-                range=[0, 24],
+                range=[24, 0],
                 tickmode="array",
                 tickvals=list(range(0, 25, 3)),
                 ticktext=[f"{hour:02d}:00" for hour in range(0, 25, 3)],

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -44,6 +44,7 @@ _PLOT_H_BY_ID: dict[str, str] = {
     "response-time": "300px",
     "iti-dist": "300px",
     "trial-count-time": "300px",
+    "training-time": "300px",
 }
 _MAX_W = "560px"  # max width per plot
 _TIMING_Y_CLIP_PCT = 95.0
@@ -258,6 +259,16 @@ def create_app() -> Dash:
             style={"height": _plot_height(gid), "width": "100%"},
             config={"displayModeBar": False},
         )
+
+    def _clock_label(hours_since_midnight: float) -> str:
+        """Format decimal hours as a zero-padded clock string."""
+        if not math.isfinite(hours_since_midnight):
+            return "unknown"
+        total_seconds = int(round(hours_since_midnight * 3600))
+        total_seconds = max(0, min(total_seconds, 24 * 3600 - 1))
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        return f"{hours:02d}:{minutes:02d}"
 
     def _row(*ids: str) -> html.Div:
         """Create a grid row of standardized graph components.
@@ -609,7 +620,7 @@ def create_app() -> Dash:
                 style={"margin": "24px 0 12px", "borderBottom": "1px solid #ddd"},
             ),
             _row("performance", "ew-rate", "side-bias", "trial-counts"),
-            _row("init-times", "median-wait", "median-rt", "water"),
+            _row("init-times", "median-wait", "median-rt", "water", "training-time"),
         ]
     )
 
@@ -2309,6 +2320,7 @@ def create_app() -> Dash:
         Output("median-wait", "figure"),
         Output("trial-counts", "figure"),
         Output("water", "figure"),
+        Output("training-time", "figure"),
         Input("subjects-recent", "value"),
         Input("subjects-older", "value"),
         Input("sessions-back", "value"),
@@ -2338,8 +2350,8 @@ def create_app() -> Dash:
             - ``auto-refresh.n_intervals``
 
         Callback Outputs:
-            Eight figures for performance, EW rate, bias, medians, trial counts,
-            and water earned.
+            Nine figures for performance, EW rate, bias, medians, trial counts,
+            water earned, and training time.
 
         Args:
             subjects_recent: Selected recent subject names.
@@ -2350,14 +2362,14 @@ def create_app() -> Dash:
             smooth_window: Moving-average window size when smoothing is enabled.
             n_intervals: Auto-refresh tick counter (unused except as trigger).
         Returns:
-            An 8-item tuple of Plotly figures in callback output order.
+            A 9-item tuple of Plotly figures in callback output order.
 
         Side Effects:
             Reads cached multi-session metrics and emits performance logs when
             profiling is enabled.
         """
         start = time.perf_counter()
-        n = 8
+        n = 9
         subjects = (subjects_recent or []) + (subjects_older or [])
 
         if not subjects:
@@ -2370,7 +2382,7 @@ def create_app() -> Dash:
 
         fig_perf, fig_ew, fig_sb = go.Figure(), go.Figure(), go.Figure()
         fig_it, fig_mrt, fig_mwt = go.Figure(), go.Figure(), go.Figure()
-        fig_tc, fig_wa = go.Figure(), go.Figure()
+        fig_tc, fig_wa, fig_tt = go.Figure(), go.Figure(), go.Figure()
 
         for i, subj in enumerate(subjects):
             c = COLORS[i % len(COLORS)]
@@ -2520,6 +2532,29 @@ def create_app() -> Dash:
                     + "</extra>",
                 )
             )
+            training_time_hours = ms.get("training_time_hours", [])
+            training_time_labels = [
+                _clock_label(float(val)) if val is not None else "unknown"
+                for val in training_time_hours
+            ]
+            fig_tt.add_trace(
+                go.Scatter(
+                    x=ms["x"],
+                    customdata=session_dates,
+                    text=training_time_labels,
+                    y=training_time_hours,
+                    mode="lines+markers",
+                    name=subj,
+                    legendgroup=grp,
+                    showlegend=False,
+                    marker=mk,
+                    line=dict(color=c),
+                    hovertemplate="session date: %{customdata}<br>"
+                    + "training time: %{text}<extra>"
+                    + subj
+                    + "</extra>",
+                )
+            )
 
         _ref_line = dict(line_dash="dash", line_color="grey", line_width=1)
 
@@ -2597,6 +2632,19 @@ def create_app() -> Dash:
             yaxis_title="volume (mL)",
             xaxis=_ms,
         )
+        _layout(
+            fig_tt,
+            title="Training Time",
+            xaxis_title="session datetime",
+            yaxis_title="time of day",
+            xaxis=_ms,
+            yaxis=dict(
+                range=[0, 24],
+                tickmode="array",
+                tickvals=list(range(0, 25, 3)),
+                ticktext=[f"{hour:02d}:00" for hour in range(0, 25, 3)],
+            ),
+        )
 
         _perf_log(
             "_update_multi",
@@ -2606,6 +2654,16 @@ def create_app() -> Dash:
             smooth=do_smooth,
             smooth_window=win,
         )
-        return fig_perf, fig_ew, fig_sb, fig_it, fig_mrt, fig_mwt, fig_tc, fig_wa
+        return (
+            fig_perf,
+            fig_ew,
+            fig_sb,
+            fig_it,
+            fig_mrt,
+            fig_mwt,
+            fig_tc,
+            fig_wa,
+            fig_tt,
+        )
 
     return app

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1136,6 +1136,20 @@ def multisession_metrics(
         )
         for ts, name in zip(d["session_dt"].tolist(), session_names, strict=False)
     ]
+    training_time_hours: list[float] = []
+    for name in session_names:
+        if (
+            isinstance(name, str)
+            and len(name) >= 15
+            and name[8] == "_"
+            and name[9:15].isdigit()
+        ):
+            hh = int(name[9:11])
+            mm = int(name[11:13])
+            ss = int(name[13:15])
+            training_time_hours.append(hh + (mm / 60.0) + (ss / 3600.0))
+        else:
+            training_time_hours.append(np.nan)
 
     ew_rate: list[float] = []
     side_bias: list[float] = []
@@ -1184,6 +1198,7 @@ def multisession_metrics(
         median_rt=np.array(median_rt_list),
         median_wait=np.array(median_wait_list),
         water=np.array(water),
+        training_time_hours=np.array(training_time_hours),
     )
 
     out: dict[str, list[Any]] = {}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,9 +19,20 @@ class _IO:
         self.kwargs = kwargs
 
 
+class _Layout(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
 class _Figure:
     def __init__(self) -> None:
-        self.layout = {}
+        self.layout = _Layout()
         self.traces = []
         self.hlines = []
         self.vlines = []
@@ -31,6 +42,9 @@ class _Figure:
 
     def add_trace(self, trace) -> None:
         self.traces.append(trace)
+
+    def update_yaxes(self, **kw) -> None:
+        self.layout.update({f"yaxis_{k}": v for k, v in kw.items()})
 
     def add_hline(self, **kw) -> None:
         self.hlines.append(kw)
@@ -74,6 +88,7 @@ def _import_app_module():
     fake_plotly.__path__ = []
     fake_go = types.ModuleType("plotly.graph_objects")
     fake_go.Figure = _Figure
+    fake_go.Scatter = lambda **kwargs: types.SimpleNamespace(type="scatter", **kwargs)
     fake_px = types.ModuleType("plotly.express")
     fake_px.colors = types.SimpleNamespace(
         qualitative=types.SimpleNamespace(Plotly=["#1f77b4", "#ff7f0e", "#2ca02c"])
@@ -452,10 +467,33 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_multi = app.callbacks["_update_multi"]
         figures = update_multi([], [], 10, None, [], 3, 0)
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )
+
+    def test_update_multi_renders_training_time_plot(self) -> None:
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = {
+            "x": ["2026-01-01 09:00:00", "2026-01-02 10:30:00"],
+            "session_dates": ["2026-01-01 09:00:00", "2026-01-02 10:30:00"],
+            "training_time_hours": [9.0, 10.5],
+            "perf_easy": [0.6, 0.7],
+            "ew_rate": [0.1, 0.2],
+            "n_with_choice": [60, 70],
+            "side_bias": [0.0, 0.1],
+            "median_init": [0.5, 0.6],
+            "median_rt": [0.2, 0.3],
+            "median_wait": [1.0, 1.2],
+            "water": [1.5, 1.7],
+        }
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        self.assertEqual(len(figures), 9)
+        self.assertEqual(figures[8].layout["title"]["text"], "Training Time")
+        self.assertEqual(figures[8].traces[0].type, "scatter")
 
     def test_update_date_options_returns_none_when_sessions_empty(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1174,6 +1174,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         self.assertEqual(list(training_trace.y), ms["training_time_hours"])
         self.assertEqual(figures[8].layout.title.text, "Training Time")
         self.assertEqual(figures[8].layout.yaxis.ticktext[3], "09:00")
+        self.assertEqual(list(figures[8].layout.yaxis.range), [24, 0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -313,6 +313,7 @@ def _make_multisession_metrics() -> dict:
     return dict(
         x=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
         session_dates=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
+        training_time_hours=[9.5 + (i * 0.25) for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -631,6 +632,7 @@ class TestAppCreationWithRealLibs(unittest.TestCase):
             _find_component_by_id(app.layout, "session-settings-toggle")
         )
         self.assertIsNotNone(_find_component_by_id(app.layout, "water-cumulative"))
+        self.assertIsNotNone(_find_component_by_id(app.layout, "training-time"))
 
     def test_create_app_places_iti_row_after_response_time_row(self):
         app = self.appmod.create_app()
@@ -870,6 +872,7 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         expected_keys = {
             "x",
             "session_dates",
+            "training_time_hours",
             "perf_easy",
             "ew_rate",
             "n_with_choice",
@@ -904,6 +907,26 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         ):
             result = self.data.multisession_metrics("subject-a", sessions_back=5)
         self.assertIsNone(result)
+
+    def test_multisession_metrics_returns_nan_training_time_when_session_name_lacks_time(
+        self,
+    ):
+        df = pd.DataFrame(
+            {
+                "session_name": ["20260105", "bad-session"],
+                "performance_easy": [0.6, 0.7],
+                "n_with_choice": [60, 65],
+                "response_values": [[-1, 1], [-1, 1]],
+                "initiation_times": [[0.5, 0.6], [0.7, 0.8]],
+                "reaction_times": [[0.2, 0.3], [0.4, 0.5]],
+            }
+        )
+        with self._patched(df)[0], self._patched(df)[1], self._patched(df)[2]:
+            result = self.data.multisession_metrics("subject-a", sessions_back=10)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(math.isnan(result["training_time_hours"][0]))
+        self.assertTrue(math.isnan(result["training_time_hours"][1]))
 
 
 # ---------------------------------------------------------------------------
@@ -1044,7 +1067,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
             figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Performance figure should have one Scatter trace
@@ -1074,7 +1097,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], [], 10, "2026-01-10", ["smooth"], 5, 0
             )
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
@@ -1103,7 +1126,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
             figures = update_multi(["subject-a"], ["subject-b"], 10, None, [], 3, 0)
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
 
     def test_update_single_skips_subjects_with_falsy_session_name(self):
         """Line 590: `if not ses: continue` — session name resolves to empty string."""
@@ -1136,9 +1159,21 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         update_multi = app.callbacks["_update_multi"]
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=None):
             figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
-        self.assertEqual(len(figures), 8)
-        for fig in figures:
-            self.assertIsInstance(fig, go.Figure)
+        self.assertEqual(len(figures), 9)
+
+    def test_update_multi_training_time_plot_uses_clock_axis(self):
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = _make_multisession_metrics()
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        training_trace = figures[8].data[0]
+        self.assertEqual(training_trace.type, "scatter")
+        self.assertEqual(list(training_trace.x), ms["x"])
+        self.assertEqual(list(training_trace.y), ms["training_time_hours"])
+        self.assertEqual(figures[8].layout.title.text, "Training Time")
+        self.assertEqual(figures[8].layout.yaxis.ticktext[3], "09:00")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a new multi-session `Training Time` plot that shows when each experiment session ran across days
- derive a `training_time_hours` series from the existing `session_name` timestamp without adding new database queries
- add unit and integration coverage for the extra callback output, clock-time axis, and malformed session-name fallback

## Why
Issue #53 asks for a quick visual readout of whether training times are stable. The dashboard already has the session timestamp encoded in `session_name`, so exposing that as a dedicated multi-session plot gives the requested at-a-glance stability signal.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`

## Notes
- `uv run chipmunk-dashboard run --debug --port 8080 --no-open` was attempted for browser verification, but live app startup is blocked in this environment because `labdata/datajoint` cannot resolve the remote MySQL host.

Closes #53
