### PR TITLE
Release main: v0.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "setuptools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "pandas",
     "numpy",
     "labdata>=0.0.22",
-    "setuptools<81",
+    # Newer setuptools releases break the real labdata/datajoint import path.
+    "setuptools==79.0.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "dash",
-    "plotly<6",
+    "plotly<7",
     "pandas",
     "numpy",
     "labdata>=0.0.22",

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -2377,9 +2377,12 @@ def create_app() -> Dash:
             grp = subj
 
             # Anchor Handling:
-            # - We use 'session_date' (YYYY-MM-DD string) as the anchor for EVERY subject.
-            # - This aligns "0" to that date for all subjects.
-            # - If date is None (startup), session_date usually defaults to latest, but we handle None.
+            # - We use 'session_date' (YYYY-MM-DD string) as the upper-date filter
+            #   for EVERY subject.
+            # - Each series still plots the true session datetime on the x-axis so
+            #   multiple sessions from one day remain visually distinct.
+            # - If date is None (startup), session_date usually defaults to latest,
+            #   but we handle None.
 
             ms = multisession_metrics(
                 subj,
@@ -2520,11 +2523,11 @@ def create_app() -> Dash:
 
         _ref_line = dict(line_dash="dash", line_color="grey", line_width=1)
 
-        _ms = dict(dtick=5, showgrid=False, zeroline=False)
+        _ms = dict(type="date", showgrid=False, zeroline=False)
         _layout(
             fig_perf,
             title="Performance (easy)",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="performance",
             yaxis_range=[0.3, 1],
             xaxis=_ms,
@@ -2534,7 +2537,7 @@ def create_app() -> Dash:
         _layout(
             fig_ew,
             title="E.W. Rate",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="e.w. rate",
             yaxis_range=[0, 1],
             xaxis=_ms,
@@ -2552,7 +2555,7 @@ def create_app() -> Dash:
         _layout(
             fig_sb,
             title="Bias Index",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="bias (R - L)",
             yaxis_range=[-0.6, 0.6],
             xaxis=_ms,
@@ -2562,35 +2565,35 @@ def create_app() -> Dash:
         _layout(
             fig_it,
             title="Median Initiation Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_mrt,
             title="Median Response Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_mwt,
             title="Median Wait Time",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="time (s)",
             xaxis=_ms,
         )
         _layout(
             fig_tc,
             title="Trials with Choice",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="trials",
             xaxis=_ms,
         )
         _layout(
             fig_wa,
             title="Water Earned",
-            xaxis_title="sessions back",
+            xaxis_title="session datetime",
             yaxis_title="volume (mL)",
             xaxis=_ms,
         )

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -2390,13 +2390,15 @@ def create_app() -> Dash:
             )
             if not ms:
                 continue
-            ht = "%{y:.2f}<extra>" + subj + "</extra>"
+            session_dates = ms.get("session_dates", [])
+            ht = "%{y:.2f}<br>session date: %{customdata}<extra>" + subj + "</extra>"
             mk = dict(color=c, size=7)
             ln = dict(color=c, width=2)
 
             fig_perf.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["perf_easy"],
                     mode="lines+markers",
                     name=subj,
@@ -2410,6 +2412,7 @@ def create_app() -> Dash:
             fig_ew.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["ew_rate"],
                     mode="lines+markers",
                     name=subj,
@@ -2423,6 +2426,7 @@ def create_app() -> Dash:
             fig_sb.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["side_bias"],
                     mode="lines+markers",
                     name=subj,
@@ -2436,6 +2440,7 @@ def create_app() -> Dash:
             fig_it.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_init"],
                     mode="lines+markers",
                     name=subj,
@@ -2443,12 +2448,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_mrt.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_rt"],
                     mode="lines+markers",
                     name=subj,
@@ -2456,12 +2464,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_mwt.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["median_wait"],
                     mode="lines+markers",
                     name=subj,
@@ -2469,12 +2480,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.3f}s<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.3f}s<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_tc.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["n_with_choice"],
                     mode="lines+markers",
                     name=subj,
@@ -2482,12 +2496,15 @@ def create_app() -> Dash:
                     showlegend=False,
                     line=dict(color=c),
                     marker=mk,
-                    hovertemplate="%{y}<extra>" + subj + "</extra>",
+                    hovertemplate="%{y}<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
             fig_wa.add_trace(
                 go.Scatter(
                     x=ms["x"],
+                    customdata=session_dates,
                     y=ms["water"],
                     mode="lines+markers",
                     name=subj,
@@ -2495,7 +2512,9 @@ def create_app() -> Dash:
                     showlegend=False,
                     marker=mk,
                     line=dict(color=c),
-                    hovertemplate="%{y:.2f} mL<extra>" + subj + "</extra>",
+                    hovertemplate="%{y:.2f} mL<br>session date: %{customdata}<extra>"
+                    + subj
+                    + "</extra>",
                 )
             )
 

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -44,6 +44,7 @@ _PLOT_H_BY_ID: dict[str, str] = {
     "response-time": "300px",
     "iti-dist": "300px",
     "trial-count-time": "300px",
+    "training-time": "300px",
 }
 _MAX_W = "560px"  # max width per plot
 _TIMING_Y_CLIP_PCT = 95.0
@@ -258,6 +259,16 @@ def create_app() -> Dash:
             style={"height": _plot_height(gid), "width": "100%"},
             config={"displayModeBar": False},
         )
+
+    def _clock_label(hours_since_midnight: float) -> str:
+        """Format decimal hours as a zero-padded clock string."""
+        if not math.isfinite(hours_since_midnight):
+            return "unknown"
+        total_seconds = int(round(hours_since_midnight * 3600))
+        total_seconds = max(0, min(total_seconds, 24 * 3600 - 1))
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        return f"{hours:02d}:{minutes:02d}"
 
     def _row(*ids: str) -> html.Div:
         """Create a grid row of standardized graph components.
@@ -609,7 +620,7 @@ def create_app() -> Dash:
                 style={"margin": "24px 0 12px", "borderBottom": "1px solid #ddd"},
             ),
             _row("performance", "ew-rate", "side-bias", "trial-counts"),
-            _row("init-times", "median-wait", "median-rt", "water"),
+            _row("init-times", "median-wait", "median-rt", "water", "training-time"),
         ]
     )
 
@@ -2309,6 +2320,7 @@ def create_app() -> Dash:
         Output("median-wait", "figure"),
         Output("trial-counts", "figure"),
         Output("water", "figure"),
+        Output("training-time", "figure"),
         Input("subjects-recent", "value"),
         Input("subjects-older", "value"),
         Input("sessions-back", "value"),
@@ -2338,8 +2350,8 @@ def create_app() -> Dash:
             - ``auto-refresh.n_intervals``
 
         Callback Outputs:
-            Eight figures for performance, EW rate, bias, medians, trial counts,
-            and water earned.
+            Nine figures for performance, EW rate, bias, medians, trial counts,
+            water earned, and training time.
 
         Args:
             subjects_recent: Selected recent subject names.
@@ -2350,14 +2362,14 @@ def create_app() -> Dash:
             smooth_window: Moving-average window size when smoothing is enabled.
             n_intervals: Auto-refresh tick counter (unused except as trigger).
         Returns:
-            An 8-item tuple of Plotly figures in callback output order.
+            A 9-item tuple of Plotly figures in callback output order.
 
         Side Effects:
             Reads cached multi-session metrics and emits performance logs when
             profiling is enabled.
         """
         start = time.perf_counter()
-        n = 8
+        n = 9
         subjects = (subjects_recent or []) + (subjects_older or [])
 
         if not subjects:
@@ -2370,7 +2382,7 @@ def create_app() -> Dash:
 
         fig_perf, fig_ew, fig_sb = go.Figure(), go.Figure(), go.Figure()
         fig_it, fig_mrt, fig_mwt = go.Figure(), go.Figure(), go.Figure()
-        fig_tc, fig_wa = go.Figure(), go.Figure()
+        fig_tc, fig_wa, fig_tt = go.Figure(), go.Figure(), go.Figure()
 
         for i, subj in enumerate(subjects):
             c = COLORS[i % len(COLORS)]
@@ -2520,6 +2532,29 @@ def create_app() -> Dash:
                     + "</extra>",
                 )
             )
+            training_time_hours = ms.get("training_time_hours", [])
+            training_time_labels = [
+                _clock_label(float(val)) if val is not None else "unknown"
+                for val in training_time_hours
+            ]
+            fig_tt.add_trace(
+                go.Scatter(
+                    x=ms["x"],
+                    customdata=session_dates,
+                    text=training_time_labels,
+                    y=training_time_hours,
+                    mode="lines+markers",
+                    name=subj,
+                    legendgroup=grp,
+                    showlegend=False,
+                    marker=mk,
+                    line=dict(color=c),
+                    hovertemplate="session date: %{customdata}<br>"
+                    + "training time: %{text}<extra>"
+                    + subj
+                    + "</extra>",
+                )
+            )
 
         _ref_line = dict(line_dash="dash", line_color="grey", line_width=1)
 
@@ -2597,6 +2632,19 @@ def create_app() -> Dash:
             yaxis_title="volume (mL)",
             xaxis=_ms,
         )
+        _layout(
+            fig_tt,
+            title="Training Time",
+            xaxis_title="session datetime",
+            yaxis_title="time of day",
+            xaxis=_ms,
+            yaxis=dict(
+                range=[24, 0],
+                tickmode="array",
+                tickvals=list(range(0, 25, 3)),
+                ticktext=[f"{hour:02d}:00" for hour in range(0, 25, 3)],
+            ),
+        )
 
         _perf_log(
             "_update_multi",
@@ -2606,6 +2654,16 @@ def create_app() -> Dash:
             smooth=do_smooth,
             smooth_window=win,
         )
-        return fig_perf, fig_ew, fig_sb, fig_it, fig_mrt, fig_mwt, fig_tc, fig_wa
+        return (
+            fig_perf,
+            fig_ew,
+            fig_sb,
+            fig_it,
+            fig_mrt,
+            fig_mwt,
+            fig_tc,
+            fig_wa,
+            fig_tt,
+        )
 
     return app

--- a/src/chipmunk_dashboard/app.py
+++ b/src/chipmunk_dashboard/app.py
@@ -710,13 +710,13 @@ def create_app() -> Dash:
         Side Effects:
             Triggers multi-session cache prewarming anchored to the latest date.
         """
+        today = _date.today().isoformat()
         if ctx.triggered_id == "today-button":
-            today = _date.today().isoformat()
-            return today, None, None, today
+            return today, None, today, today
 
         subjects = (subjects_recent or []) + (subjects_older or [])
         if not subjects:
-            return None, None, None, None
+            return None, None, today, today
 
         all_dates = [
             f"{s[:4]}-{s[4:6]}-{s[6:8]}"
@@ -726,12 +726,12 @@ def create_app() -> Dash:
         ]
 
         if not all_dates:
-            return None, None, None, None
+            return None, None, today, today
 
         min_d = min(all_dates)
-        max_d = max(all_dates)
+        max_d = min(max(all_dates), today)
         prewarm_multisession_cache(subjects, sessions_back=30, start_date=max_d)
-        return max_d, min_d, max_d, max_d  # Default to latest
+        return max_d, min_d, today, max_d
 
     @app.callback(
         Output("session-time", "options"),

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1136,6 +1136,20 @@ def multisession_metrics(
         )
         for ts, name in zip(d["session_dt"].tolist(), session_names, strict=False)
     ]
+    training_time_hours: list[float] = []
+    for name in session_names:
+        if (
+            isinstance(name, str)
+            and len(name) >= 15
+            and name[8] == "_"
+            and name[9:15].isdigit()
+        ):
+            hh = int(name[9:11])
+            mm = int(name[11:13])
+            ss = int(name[13:15])
+            training_time_hours.append(hh + (mm / 60.0) + (ss / 3600.0))
+        else:
+            training_time_hours.append(np.nan)
 
     ew_rate: list[float] = []
     side_bias: list[float] = []
@@ -1184,6 +1198,7 @@ def multisession_metrics(
         median_rt=np.array(median_rt_list),
         median_wait=np.array(median_wait_list),
         water=np.array(water),
+        training_time_hours=np.array(training_time_hours),
     )
 
     out: dict[str, list[Any]] = {}

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1116,6 +1116,12 @@ def multisession_metrics(
     initiation_values = d["initiation_times"].tolist()
     reaction_values = d["reaction_times"].tolist()
     session_names = d["session_name"].tolist()
+    session_dates = [
+        f"{name[:4]}-{name[4:6]}-{name[6:8]}"
+        if isinstance(name, str) and len(name) >= 8
+        else str(name)
+        for name in session_names
+    ]
 
     ew_rate: list[float] = []
     side_bias: list[float] = []
@@ -1184,6 +1190,7 @@ def multisession_metrics(
             out[k] = np.asarray(v).tolist()
 
     out["x"] = [float(x) for x in x_axis]
+    out["session_dates"] = session_dates
     _perf_log(
         "multisession_metrics",
         start,

--- a/src/chipmunk_dashboard/data.py
+++ b/src/chipmunk_dashboard/data.py
@@ -1073,10 +1073,18 @@ def multisession_metrics(
 
     df = df.sort_values("session_name")
 
-    # Parse session dates for filtering
-    df["date"] = pd.to_datetime(
-        df["session_name"].str.slice(0, 8), format="%Y%m%d", errors="coerce"
+    # Parse full session datetimes so same-day sessions keep distinct x positions.
+    df["session_dt"] = pd.to_datetime(
+        df["session_name"], format="%Y%m%d_%H%M%S", errors="coerce"
     )
+    missing_dt = df["session_dt"].isna()
+    if missing_dt.any():
+        df.loc[missing_dt, "session_dt"] = pd.to_datetime(
+            df.loc[missing_dt, "session_name"].astype(str).str.slice(0, 8),
+            format="%Y%m%d",
+            errors="coerce",
+        )
+    df["date"] = df["session_dt"].dt.normalize()
 
     # Filter by date if provided
     if start_date:
@@ -1084,9 +1092,9 @@ def multisession_metrics(
         # Keep sessions <= start_date
         df = df[df["date"] <= anchor_dt]
     else:
-        # If no date provided, use the latest session date of this subject as anchor
+        # If no date provided, use the latest session timestamp of this subject.
         if not df.empty:
-            anchor_dt = df["date"].iloc[-1]
+            anchor_dt = df["session_dt"].iloc[-1]
         else:  # pragma: no cover — df can't be empty here (already checked above)
             _perf_log("multisession_metrics", start, subject=subject, sessions=0)
             return None
@@ -1099,28 +1107,34 @@ def multisession_metrics(
     wait_medians = get_wait_medians_for_sessions(subject, d_session_names)
     water_by_session = get_subject_water(subject)
 
-    # Calculate X-axis (Days relative to anchor_dt)
-    # This aligns 0 to the shared anchor date (or this subject's latest date if none shared)
     try:
-        anchor_ts = pd.Timestamp(anchor_dt)
         x_axis = [
-            float((pd.Timestamp(v) - anchor_ts).days) if pd.notna(v) else float("nan")
-            for v in d["date"].tolist()
+            pd.Timestamp(v).isoformat(sep=" ")
+            if pd.notna(v)
+            else pd.Timestamp(d["date"].iloc[i]).isoformat(sep=" ")
+            for i, v in enumerate(d["session_dt"].tolist())
         ]
-    except (
-        Exception
-    ):  # pragma: no cover — defensive fallback for unexpected timestamp types
-        x_axis = [float(i) for i in range(-len(d) + 1, 1)]
+    except Exception:  # pragma: no cover — defensive fallback for unexpected types
+        x_axis = [
+            pd.Timestamp(v).isoformat(sep=" ") if pd.notna(v) else str(name)
+            for v, name in zip(
+                d["date"].tolist(), d["session_name"].tolist(), strict=False
+            )
+        ]
 
     response_values = d["response_values"].tolist()
     initiation_values = d["initiation_times"].tolist()
     reaction_values = d["reaction_times"].tolist()
     session_names = d["session_name"].tolist()
     session_dates = [
-        f"{name[:4]}-{name[4:6]}-{name[6:8]}"
-        if isinstance(name, str) and len(name) >= 8
-        else str(name)
-        for name in session_names
+        pd.Timestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+        if pd.notna(ts)
+        else (
+            f"{name[:4]}-{name[4:6]}-{name[6:8]}"
+            if isinstance(name, str) and len(name) >= 8
+            else str(name)
+        )
+        for ts, name in zip(d["session_dt"].tolist(), session_names, strict=False)
     ]
 
     ew_rate: list[float] = []
@@ -1172,7 +1186,7 @@ def multisession_metrics(
         water=np.array(water),
     )
 
-    out: dict[str, list[float]] = {}
+    out: dict[str, list[Any]] = {}
     if smooth and smooth_window > 1:
         # Simple moving average, handling NaNs
         # We can use pandas rolling on a temporary series for each metric
@@ -1189,7 +1203,7 @@ def multisession_metrics(
         for k, v in res.items():
             out[k] = np.asarray(v).tolist()
 
-    out["x"] = [float(x) for x in x_axis]
+    out["x"] = x_axis
     out["session_dates"] = session_dates
     _perf_log(
         "multisession_metrics",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,9 +19,20 @@ class _IO:
         self.kwargs = kwargs
 
 
+class _Layout(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
 class _Figure:
     def __init__(self) -> None:
-        self.layout = {}
+        self.layout = _Layout()
         self.traces = []
         self.hlines = []
         self.vlines = []
@@ -31,6 +42,9 @@ class _Figure:
 
     def add_trace(self, trace) -> None:
         self.traces.append(trace)
+
+    def update_yaxes(self, **kw) -> None:
+        self.layout.update({f"yaxis_{k}": v for k, v in kw.items()})
 
     def add_hline(self, **kw) -> None:
         self.hlines.append(kw)
@@ -74,6 +88,7 @@ def _import_app_module():
     fake_plotly.__path__ = []
     fake_go = types.ModuleType("plotly.graph_objects")
     fake_go.Figure = _Figure
+    fake_go.Scatter = lambda **kwargs: types.SimpleNamespace(type="scatter", **kwargs)
     fake_px = types.ModuleType("plotly.express")
     fake_px.colors = types.SimpleNamespace(
         qualitative=types.SimpleNamespace(Plotly=["#1f77b4", "#ff7f0e", "#2ca02c"])
@@ -500,10 +515,33 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_multi = app.callbacks["_update_multi"]
         figures = update_multi([], [], 10, None, [], 3, 0)
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         self.assertEqual(
             figures[0].layout["annotations"][0]["text"], "Select subject(s)"
         )
+
+    def test_update_multi_renders_training_time_plot(self) -> None:
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = {
+            "x": ["2026-01-01 09:00:00", "2026-01-02 10:30:00"],
+            "session_dates": ["2026-01-01 09:00:00", "2026-01-02 10:30:00"],
+            "training_time_hours": [9.0, 10.5],
+            "perf_easy": [0.6, 0.7],
+            "ew_rate": [0.1, 0.2],
+            "n_with_choice": [60, 70],
+            "side_bias": [0.0, 0.1],
+            "median_init": [0.5, 0.6],
+            "median_rt": [0.2, 0.3],
+            "median_wait": [1.0, 1.2],
+            "water": [1.5, 1.7],
+        }
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        self.assertEqual(len(figures), 9)
+        self.assertEqual(figures[8].layout["title"]["text"], "Training Time")
+        self.assertEqual(figures[8].traces[0].type, "scatter")
 
     def test_update_date_options_returns_none_when_sessions_empty(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -180,39 +180,87 @@ class TestAppUtilities(unittest.TestCase):
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
 
-        self.assertEqual(update_date_options([], [], 0, 0), (None, None, None, None))
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        with mock.patch.object(self.appmod, "_date", _FakeDate):
+            self.assertEqual(
+                update_date_options([], [], 0, 0),
+                (None, None, "2026-01-10", "2026-01-10"),
+            )
+
+            with (
+                mock.patch.object(
+                    self.appmod,
+                    "get_sessions",
+                    return_value=["20260101_010101", "20260103_010101", "bad"],
+                ),
+                mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
+            ):
+                result = update_date_options([], ["subject-a"], 0, 0)
+
+            self.assertEqual(
+                result, ("2026-01-03", "2026-01-01", "2026-01-10", "2026-01-03")
+            )
+            prewarm.assert_called_once_with(
+                ["subject-a"], sessions_back=30, start_date="2026-01-03"
+            )
+
+    def test_update_date_options_today_button_returns_todays_date(self) -> None:
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        self.appmod.ctx.triggered_id = "today-button"
+        try:
+            with mock.patch.object(self.appmod, "_date", _FakeDate):
+                date_val, min_d, max_d, month = update_date_options([], [], 0, 1)
+        finally:
+            self.appmod.ctx.triggered_id = None
+
+        self.assertEqual(date_val, "2026-01-10")
+        self.assertIsNone(min_d)
+        self.assertEqual(max_d, "2026-01-10")
+        self.assertEqual(month, "2026-01-10")
+
+    def test_update_date_options_caps_future_sessions_at_today(self) -> None:
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
 
         with (
+            mock.patch.object(self.appmod, "_date", _FakeDate),
             mock.patch.object(
                 self.appmod,
                 "get_sessions",
-                return_value=["20260101_010101", "20260103_010101", "bad"],
+                return_value=["20260105_010101", "20260114_120000"],
             ),
             mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
         ):
             result = update_date_options([], ["subject-a"], 0, 0)
 
         self.assertEqual(
-            result, ("2026-01-03", "2026-01-01", "2026-01-03", "2026-01-03")
+            result, ("2026-01-10", "2026-01-05", "2026-01-10", "2026-01-10")
         )
         prewarm.assert_called_once_with(
-            ["subject-a"], sessions_back=30, start_date="2026-01-03"
+            ["subject-a"], sessions_back=30, start_date="2026-01-10"
         )
-
-    def test_update_date_options_today_button_returns_todays_date(self) -> None:
-        app = self.appmod.create_app()
-        update_date_options = app.callbacks["_update_date_options"]
-        self.appmod.ctx.triggered_id = "today-button"
-        try:
-            date_val, min_d, max_d, month = update_date_options([], [], 0, 1)
-        finally:
-            self.appmod.ctx.triggered_id = None
-        from datetime import date
-
-        self.assertEqual(date_val, date.today().isoformat())
-        self.assertIsNone(min_d)
-        self.assertIsNone(max_d)
-        self.assertEqual(month, date.today().isoformat())
 
     def test_update_time_options_filters_and_defaults_to_latest(self) -> None:
         app = self.appmod.create_app()
@@ -462,14 +510,30 @@ class TestAppUtilities(unittest.TestCase):
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=[]):
             result = update_date_options([], ["subject-a"], 0, 0)
-        self.assertEqual(result, (None, None, None, None))
+        self.assertEqual(
+            result,
+            (
+                None,
+                None,
+                self.appmod._date.today().isoformat(),
+                self.appmod._date.today().isoformat(),
+            ),
+        )
 
     def test_update_date_options_returns_none_when_all_sessions_too_short(self) -> None:
         app = self.appmod.create_app()
         update_date_options = app.callbacks["_update_date_options"]
         with mock.patch.object(self.appmod, "get_sessions", return_value=["short"]):
             result = update_date_options([], ["subject-a"], 0, 0)
-        self.assertEqual(result, (None, None, None, None))
+        self.assertEqual(
+            result,
+            (
+                None,
+                None,
+                self.appmod._date.today().isoformat(),
+                self.appmod._date.today().isoformat(),
+            ),
+        )
 
     def test_update_time_options_returns_empty_when_no_sessions_on_date(self) -> None:
         app = self.appmod.create_app()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -311,8 +311,8 @@ def _make_multisession_metrics() -> dict:
     n = 10
     rng = np.random.default_rng(42)
     return dict(
-        x=[float(i - 9) for i in range(n)],
-        session_dates=[f"2026-01-{i + 1:02d}" for i in range(n)],
+        x=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
+        session_dates=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -1061,6 +1061,9 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         perf_trace = figures[0].data[0]
         self.assertEqual(list(perf_trace.customdata), ms["session_dates"])
         self.assertIn("session date: %{customdata}", perf_trace.hovertemplate)
+        self.assertEqual(list(perf_trace.x), ms["x"])
+        self.assertEqual(figures[0].layout.xaxis.type, "date")
+        self.assertEqual(figures[0].layout.xaxis.title.text, "session datetime")
 
     def test_update_multi_smooth_enabled_still_returns_eight_figures(self):
         app = self.appmod.create_app()
@@ -1260,6 +1263,48 @@ class TestDataNonEmptyPaths(unittest.TestCase):
         self.assertIsNotNone(result)
         # Only Jan 1-5 pass the <= filter; sessions_back=10 keeps all 5.
         self.assertEqual(len(result["x"]), 5)
+
+    def test_multisession_metrics_keeps_same_day_sessions_distinct_on_x_axis(self):
+        df = pd.DataFrame(
+            {
+                "session_name": [
+                    "20260105_090000",
+                    "20260105_150000",
+                    "20260106_120000",
+                ],
+                "performance_easy": [0.6, 0.7, 0.8],
+                "n_with_choice": [60, 65, 70],
+                "response_values": [[-1, 1]] * 3,
+                "initiation_times": [[0.5, 0.6]] * 3,
+                "reaction_times": [[0.2, 0.3]] * 3,
+            }
+        )
+        with (
+            mock.patch.object(self.data, "get_subject_data", return_value=df),
+            mock.patch.object(
+                self.data, "get_wait_medians_for_sessions", return_value={}
+            ),
+            mock.patch.object(self.data, "get_subject_water", return_value={}),
+        ):
+            result = self.data.multisession_metrics("subject-a", sessions_back=10)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["x"],
+            [
+                "2026-01-05 09:00:00",
+                "2026-01-05 15:00:00",
+                "2026-01-06 12:00:00",
+            ],
+        )
+        self.assertEqual(
+            result["session_dates"],
+            [
+                "2026-01-05 09:00:00",
+                "2026-01-05 15:00:00",
+                "2026-01-06 12:00:00",
+            ],
+        )
 
     # -- multisession_metrics: side_bias no-choice path (line 730) ------------
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1105,6 +1105,35 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
 
         self.assertEqual(len(figures), 8)
 
+    def test_update_date_options_caps_future_dates_at_today(self):
+        app = self.appmod.create_app()
+        update_date_options = app.callbacks["_update_date_options"]
+
+        class _FakeDate:
+            @staticmethod
+            def today():
+                from datetime import date
+
+                return date(2026, 1, 10)
+
+        with (
+            mock.patch.object(self.appmod, "_date", _FakeDate),
+            mock.patch.object(
+                self.appmod,
+                "get_sessions",
+                return_value=["20260105_010101", "20260114_120000"],
+            ),
+            mock.patch.object(self.appmod, "prewarm_multisession_cache") as prewarm,
+        ):
+            result = update_date_options([], ["subject-a"], 0, 0)
+
+        self.assertEqual(
+            result, ("2026-01-10", "2026-01-05", "2026-01-10", "2026-01-10")
+        )
+        prewarm.assert_called_once_with(
+            ["subject-a"], sessions_back=30, start_date="2026-01-10"
+        )
+
     def test_update_single_skips_subjects_with_falsy_session_name(self):
         """Line 590: `if not ses: continue` — session name resolves to empty string."""
         app = self.appmod.create_app()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -313,6 +313,7 @@ def _make_multisession_metrics() -> dict:
     return dict(
         x=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
         session_dates=[f"2026-01-{i + 1:02d} 12:00:00" for i in range(n)],
+        training_time_hours=[9.5 + (i * 0.25) for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -631,6 +632,7 @@ class TestAppCreationWithRealLibs(unittest.TestCase):
             _find_component_by_id(app.layout, "session-settings-toggle")
         )
         self.assertIsNotNone(_find_component_by_id(app.layout, "water-cumulative"))
+        self.assertIsNotNone(_find_component_by_id(app.layout, "training-time"))
 
     def test_create_app_places_iti_row_after_response_time_row(self):
         app = self.appmod.create_app()
@@ -870,6 +872,7 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         expected_keys = {
             "x",
             "session_dates",
+            "training_time_hours",
             "perf_easy",
             "ew_rate",
             "n_with_choice",
@@ -904,6 +907,26 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         ):
             result = self.data.multisession_metrics("subject-a", sessions_back=5)
         self.assertIsNone(result)
+
+    def test_multisession_metrics_returns_nan_training_time_when_session_name_lacks_time(
+        self,
+    ):
+        df = pd.DataFrame(
+            {
+                "session_name": ["20260105", "bad-session"],
+                "performance_easy": [0.6, 0.7],
+                "n_with_choice": [60, 65],
+                "response_values": [[-1, 1], [-1, 1]],
+                "initiation_times": [[0.5, 0.6], [0.7, 0.8]],
+                "reaction_times": [[0.2, 0.3], [0.4, 0.5]],
+            }
+        )
+        with self._patched(df)[0], self._patched(df)[1], self._patched(df)[2]:
+            result = self.data.multisession_metrics("subject-a", sessions_back=10)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(math.isnan(result["training_time_hours"][0]))
+        self.assertTrue(math.isnan(result["training_time_hours"][1]))
 
 
 # ---------------------------------------------------------------------------
@@ -1044,7 +1067,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
             figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
         # Performance figure should have one Scatter trace
@@ -1074,7 +1097,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
                 ["subject-a"], [], 10, "2026-01-10", ["smooth"], 5, 0
             )
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
         for fig in figures:
             self.assertIsInstance(fig, go.Figure)
 
@@ -1103,7 +1126,7 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
             figures = update_multi(["subject-a"], ["subject-b"], 10, None, [], 3, 0)
 
-        self.assertEqual(len(figures), 8)
+        self.assertEqual(len(figures), 9)
 
     def test_update_date_options_caps_future_dates_at_today(self):
         app = self.appmod.create_app()
@@ -1165,9 +1188,22 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         update_multi = app.callbacks["_update_multi"]
         with mock.patch.object(self.appmod, "multisession_metrics", return_value=None):
             figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
-        self.assertEqual(len(figures), 8)
-        for fig in figures:
-            self.assertIsInstance(fig, go.Figure)
+        self.assertEqual(len(figures), 9)
+
+    def test_update_multi_training_time_plot_uses_clock_axis(self):
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = _make_multisession_metrics()
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        training_trace = figures[8].data[0]
+        self.assertEqual(training_trace.type, "scatter")
+        self.assertEqual(list(training_trace.x), ms["x"])
+        self.assertEqual(list(training_trace.y), ms["training_time_hours"])
+        self.assertEqual(figures[8].layout.title.text, "Training Time")
+        self.assertEqual(figures[8].layout.yaxis.ticktext[3], "09:00")
+        self.assertEqual(list(figures[8].layout.yaxis.range), [24, 0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -312,6 +312,7 @@ def _make_multisession_metrics() -> dict:
     rng = np.random.default_rng(42)
     return dict(
         x=[float(i - 9) for i in range(n)],
+        session_dates=[f"2026-01-{i + 1:02d}" for i in range(n)],
         perf_easy=rng.uniform(0.5, 0.9, n).tolist(),
         ew_rate=rng.uniform(0.0, 0.3, n).tolist(),
         n_with_choice=[int(v) for v in rng.integers(50, 120, n)],
@@ -868,6 +869,7 @@ class TestMultisessionMetricsWithRealLibs(unittest.TestCase):
         self.assertIsNotNone(result)
         expected_keys = {
             "x",
+            "session_dates",
             "perf_easy",
             "ew_rate",
             "n_with_choice",
@@ -1048,6 +1050,17 @@ class TestCallbacksWithRealPlotly(unittest.TestCase):
         # Performance figure should have one Scatter trace
         self.assertEqual(len(figures[0].data), 1)
         self.assertIsInstance(figures[0].data[0], go.Scatter)
+
+    def test_update_multi_hover_shows_session_date(self):
+        app = self.appmod.create_app()
+        update_multi = app.callbacks["_update_multi"]
+        ms = _make_multisession_metrics()
+        with mock.patch.object(self.appmod, "multisession_metrics", return_value=ms):
+            figures = update_multi(["subject-a"], [], 10, "2026-01-10", [], 3, 0)
+
+        perf_trace = figures[0].data[0]
+        self.assertEqual(list(perf_trace.customdata), ms["session_dates"])
+        self.assertIn("session date: %{customdata}", perf_trace.hovertemplate)
 
     def test_update_multi_smooth_enabled_still_returns_eight_figures(self):
         app = self.appmod.create_app()

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dash" },
-    { name = "labdata", specifier = ">=0.1.7" },
+    { name = "labdata", specifier = ">=0.0.22" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly", specifier = "<7" },

--- a/uv.lock
+++ b/uv.lock
@@ -339,7 +339,7 @@ requires-dist = [
     { name = "labdata", specifier = ">=0.0.22" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "plotly", specifier = "<6" },
+    { name = "plotly", specifier = "<7" },
     { name = "setuptools", specifier = "==79.0.1" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly", specifier = "<6" },
-    { name = "setuptools", specifier = "<81" },
+    { name = "setuptools", specifier = "==79.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -2470,11 +2470,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.0.0"
+version = "79.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/80/97e25f0f1e4067677806084b7382a6ff9979f3d15119375c475c288db9d7/setuptools-80.0.0.tar.gz", hash = "sha256:c40a5b3729d58dd749c0f08f1a07d134fb8a0a3d7f87dc33e7c5e1f762138650", size = 1354221, upload-time = "2025-04-27T17:21:10.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/63/5517029d6696ddf2bd378d46f63f479be001c31b462303170a1da57650cb/setuptools-80.0.0-py3-none-any.whl", hash = "sha256:a38f898dcd6e5380f4da4381a87ec90bd0a7eec23d204a5552e80ee3cab6bd27", size = 1240907, upload-time = "2025-04-27T17:21:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- prepare a stable release snapshot from current `dev` for merge into `main`
- include the recent dashboard updates: Plotly 6 compatibility, `setuptools==79.0.1` pinning, multisession session-datetime improvements, future-date blocking, and the new training-time plot
- keep the project version at `0.1.0`, which matches `pyproject.toml` and would make this the first GitHub release tag

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=src/chipmunk_dashboard --cov-fail-under=90`
- `RUN_PLAYWRIGHT=1 uv run pytest tests/test_playwright_ui.py`

## Release Notes Draft
### Added
- training-time multi-session plot

### Changed
- multisession plots now use session datetimes in hover/context
- session picker blocks future dates
- Plotly 6 compatibility updates

### Fixed
- pinned `setuptools==79.0.1` to avoid the `datajoint`/`pkg_resources` breakage path
